### PR TITLE
Opt in auto derivation

### DIFF
--- a/modules/bench/src/main/scala/doobie/bench/select.scala
+++ b/modules/bench/src/main/scala/doobie/bench/select.scala
@@ -5,6 +5,7 @@
 package doobie.bench
 
 import cats.effect.IO
+import doobie.generic.auto.*
 import doobie.syntax.connectionio.*
 import doobie.syntax.string.*
 import doobie.util.transactor.Transactor

--- a/modules/bench/src/main/scala/doobie/bench/text.scala
+++ b/modules/bench/src/main/scala/doobie/bench/text.scala
@@ -4,11 +4,14 @@
 
 package doobie.bench
 
-import cats.syntax.all.*
+import cats.syntax.apply.*
+import cats.syntax.foldable.*
+import cats.syntax.functor.*
 import doobie.FPS
 import doobie.HC
 import doobie.HPS
 import doobie.free.connection.ConnectionIO
+import doobie.generic.auto.*
 import doobie.postgres.implicits.*
 import doobie.syntax.connectionio.*
 import doobie.syntax.string.*
@@ -39,7 +42,7 @@ class text {
         people(n).foreach { p =>
           ps.setString(1, p.name)
           ps.setInt(2, p.age)
-          ps.addBatch
+          ps.addBatch()
         }
         ps.executeBatch.sum
       },

--- a/modules/core/src/main/scala-2/doobie/util/GetPlatform.scala
+++ b/modules/core/src/main/scala-2/doobie/util/GetPlatform.scala
@@ -10,15 +10,15 @@ import shapeless.ops.hlist.IsHCons
 trait GetPlatform {
 
   /** @group Instances */
-  implicit def unaryProductGet[A, L <: HList, H, T <: HList](
-    implicit
+  implicit def unaryProductGet[A, L <: HList, H, T <: HList](implicit
     G: Generic.Aux[A, L],
     C: IsHCons.Aux[L, H, T],
-    H: Lazy[Get[H]],
+    H: => Get[H],
     E: (H :: HNil) =:= L,
-  ): Get[A] = {
+  ): MkGet[A] = {
     void(C) // C drives inference but is not used directly
-    H.value.tmap[A](h => G.from(h :: HNil))
+    val get = H.tmap[A](h => G.from(h :: HNil))
+    MkGet.lift(get)
   }
 
 }

--- a/modules/core/src/main/scala-2/doobie/util/PutPlatform.scala
+++ b/modules/core/src/main/scala-2/doobie/util/PutPlatform.scala
@@ -10,15 +10,15 @@ import shapeless.ops.hlist.IsHCons
 trait PutPlatform {
 
   /** @group Instances */
-  implicit def unaryProductPut[A, L <: HList, H, T <: HList](
-    implicit
+  implicit def unaryProductPut[A, L <: HList, H, T <: HList](implicit
     G: Generic.Aux[A, L],
     C: IsHCons.Aux[L, H, T],
-    H: Lazy[Put[H]],
+    H: => Put[H],
     E: (H :: HNil) =:= L,
-  ): Put[A] = {
+  ): MkPut[A] = {
     void(E) // E is a necessary constraint but isn't used directly
-    H.value.contramap[A](a => G.to(a).head)
+    val put = H.contramap[A](a => G.to(a).head)
+    MkPut.lift(put)
   }
 
 }

--- a/modules/core/src/main/scala-2/doobie/util/WritePlatform.scala
+++ b/modules/core/src/main/scala-2/doobie/util/WritePlatform.scala
@@ -9,21 +9,22 @@ import shapeless.<:!<
 import shapeless.Generic
 import shapeless.HList
 import shapeless.HNil
-import shapeless.Lazy
+import shapeless.OrElse
 import shapeless.labelled.FieldType
 
 trait WritePlatform extends LowerPriorityWrite {
 
-  implicit def recordWrite[K <: Symbol, H, T <: HList](
-    implicit
-    H: Lazy[Write[H]],
-    T: Lazy[Write[T]],
-  ): Write[FieldType[K, H] :: T] = {
-    new Write(
-      H.value.puts ++ T.value.puts,
-      { case h :: t => H.value.toList(h) ++ T.value.toList(t) },
-      { case (ps, n, h :: t) => H.value.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + H.value.length, t) },
-      { case (rs, n, h :: t) => H.value.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + H.value.length, t) },
+  implicit def recordWrite[K <: Symbol, H, T <: HList](implicit
+    H: => Write[H] OrElse MkWrite[H],
+    T: => MkWrite[T],
+  ): MkWrite[FieldType[K, H] :: T] = {
+    val head = H.unify
+
+    new MkWrite(
+      head.puts ++ T.puts,
+      { case h :: t => head.toList(h) ++ T.toList(t) },
+      { case (ps, n, h :: t) => head.unsafeSet(ps, n, h); T.unsafeSet(ps, n + head.length, t) },
+      { case (rs, n, h :: t) => head.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + head.length, t) },
     )
   }
 
@@ -31,86 +32,84 @@ trait WritePlatform extends LowerPriorityWrite {
 
 trait LowerPriorityWrite extends EvenLowerPriorityWrite {
 
-  implicit def product[H, T <: HList](
-    implicit
-    H: Lazy[Write[H]],
-    T: Lazy[Write[T]],
-  ): Write[H :: T] =
-    new Write(
-      H.value.puts ++ T.value.puts,
-      { case h :: t => H.value.toList(h) ++ T.value.toList(t) },
-      { case (ps, n, h :: t) => H.value.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + H.value.length, t) },
-      { case (rs, n, h :: t) => H.value.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + H.value.length, t) },
+  implicit def product[H, T <: HList](implicit
+    H: => Write[H] OrElse MkWrite[H],
+    T: => MkWrite[T],
+  ): MkWrite[H :: T] = {
+    val head = H.unify
+
+    new MkWrite(
+      head.puts ++ T.puts,
+      { case h :: t => head.toList(h) ++ T.toList(t) },
+      { case (ps, n, h :: t) => head.unsafeSet(ps, n, h); T.unsafeSet(ps, n + head.length, t) },
+      { case (rs, n, h :: t) => head.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + head.length, t) },
     )
+  }
 
-  implicit def emptyProduct: Write[HNil] =
-    new Write[HNil](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
+  implicit val emptyProduct: MkWrite[HNil] =
+    new MkWrite[HNil](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
 
-  implicit def generic[B, A](implicit gen: Generic.Aux[B, A], A: Lazy[Write[A]]): Write[B] =
-    new Write[B](
-      A.value.puts,
-      b => A.value.toList(gen.to(b)),
-      (ps, n, b) => A.value.unsafeSet(ps, n, gen.to(b)),
-      (rs, n, b) => A.value.unsafeUpdate(rs, n, gen.to(b)),
+  implicit def generic[B, A](implicit gen: Generic.Aux[B, A], A: => MkWrite[A]): MkWrite[B] =
+    new MkWrite[B](
+      A.puts,
+      b => A.toList(gen.to(b)),
+      (ps, n, b) => A.unsafeSet(ps, n, gen.to(b)),
+      (rs, n, b) => A.unsafeUpdate(rs, n, gen.to(b)),
     )
 
 }
 
 trait EvenLowerPriorityWrite {
 
-  implicit val ohnil: Write[Option[HNil]] =
-    new Write[Option[HNil]](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
+  implicit val ohnil: MkWrite[Option[HNil]] =
+    new MkWrite[Option[HNil]](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
 
-  implicit def ohcons1[H, T <: HList](
-    implicit
-    H: Lazy[Write[Option[H]]],
-    T: Lazy[Write[Option[T]]],
+  implicit def ohcons1[H, T <: HList](implicit
+    H: => Write[Option[H]] OrElse MkWrite[Option[H]],
+    T: => MkWrite[Option[T]],
     N: H <:!< Option[α] forSome { type α },
-  ): Write[Option[H :: T]] = {
+  ): MkWrite[Option[H :: T]] = {
     void(N)
+    val head = H.unify
 
     def split[A](i: Option[H :: T])(f: (Option[H], Option[T]) => A): A =
       i.fold(f(None, None)) { case h :: t => f(Some(h), Some(t)) }
 
-    new Write(
-      H.value.puts ++ T.value.puts,
-      split(_) { (h, t) => H.value.toList(h) ++ T.value.toList(t) },
-      (ps, n, i) => split(i) { (h, t) => H.value.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + H.value.length, t) },
-      (rs, n, i) =>
-        split(i) { (h, t) => H.value.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + H.value.length, t) },
+    new MkWrite(
+      head.puts ++ T.puts,
+      split(_) { (h, t) => head.toList(h) ++ T.toList(t) },
+      (ps, n, i) => split(i) { (h, t) => head.unsafeSet(ps, n, h); T.unsafeSet(ps, n + head.length, t) },
+      (rs, n, i) => split(i) { (h, t) => head.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + head.length, t) },
     )
 
   }
 
-  implicit def ohcons2[H, T <: HList](
-    implicit
-    H: Lazy[Write[Option[H]]],
-    T: Lazy[Write[Option[T]]],
-  ): Write[Option[Option[H] :: T]] = {
+  implicit def ohcons2[H, T <: HList](implicit
+    H: => Write[Option[H]] OrElse MkWrite[Option[H]],
+    T: => MkWrite[Option[T]],
+  ): MkWrite[Option[Option[H] :: T]] = {
+    val head = H.unify
 
     def split[A](i: Option[Option[H] :: T])(f: (Option[H], Option[T]) => A): A =
       i.fold(f(None, None)) { case oh :: t => f(oh, Some(t)) }
 
-    new Write(
-      H.value.puts ++ T.value.puts,
-      split(_) { (h, t) => H.value.toList(h) ++ T.value.toList(t) },
-      (ps, n, i) => split(i) { (h, t) => H.value.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + H.value.length, t) },
-      (rs, n, i) =>
-        split(i) { (h, t) => H.value.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + H.value.length, t) },
+    new MkWrite(
+      head.puts ++ T.puts,
+      split(_) { (h, t) => head.toList(h) ++ T.toList(t) },
+      (ps, n, i) => split(i) { (h, t) => head.unsafeSet(ps, n, h); T.unsafeSet(ps, n + head.length, t) },
+      (rs, n, i) => split(i) { (h, t) => head.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + head.length, t) },
     )
 
   }
 
-  implicit def ogeneric[B, A <: HList](
-    implicit
+  implicit def ogeneric[B, A <: HList](implicit
     G: Generic.Aux[B, A],
-    A: Lazy[Write[Option[A]]],
-  ): Write[Option[B]] =
-    new Write(
-      A.value.puts,
-      b => A.value.toList(b.map(G.to)),
-      (rs, n, a) => A.value.unsafeSet(rs, n, a.map(G.to)),
-      (rs, n, a) => A.value.unsafeUpdate(rs, n, a.map(G.to)),
-    )
+    A: => MkWrite[Option[A]],
+  ): MkWrite[Option[B]] = new MkWrite(
+    A.puts,
+    b => A.toList(b.map(G.to)),
+    (rs, n, a) => A.unsafeSet(rs, n, a.map(G.to)),
+    (rs, n, a) => A.unsafeUpdate(rs, n, a.map(G.to)),
+  )
 
 }

--- a/modules/core/src/main/scala-3/doobie/util/GetPlatform.scala
+++ b/modules/core/src/main/scala-3/doobie/util/GetPlatform.scala
@@ -9,12 +9,12 @@ import scala.deriving.Mirror
 trait GetPlatform {
 
   // Get is available for single-element products.
-  given x[P <: Product, A](
-    using
+  given x[P <: Product, A](using
     p: Mirror.ProductOf[P],
     i: p.MirroredElemTypes =:= (A *: EmptyTuple),
     g: Get[A],
-  ): Get[P] =
-    g.map(a => p.fromProduct(a *: EmptyTuple))
-
+  ): MkGet[P] = {
+    val get = g.map(a => p.fromProduct(a *: EmptyTuple))
+    MkGet.lift(get)
+  }
 }

--- a/modules/core/src/main/scala-3/doobie/util/PutPlatform.scala
+++ b/modules/core/src/main/scala-3/doobie/util/PutPlatform.scala
@@ -9,11 +9,12 @@ import scala.deriving.Mirror
 trait PutPlatform {
 
   // Put is available for single-element products.
-  given [P <: Product, A](
-    using
+  given [P <: Product, A](using
     m: Mirror.ProductOf[P],
     i: m.MirroredElemTypes =:= (A *: EmptyTuple),
     p: Put[A],
-  ): Put[P] =
-    p.contramap(p => i(Tuple.fromProductTyped(p)).head)
+  ): MkPut[P] = {
+    val put: Put[P] = p.contramap(p => i(Tuple.fromProductTyped(p)).head)
+    MkPut.lift(put)
+  }
 }

--- a/modules/core/src/main/scala-3/doobie/util/ReadPlatform.scala
+++ b/modules/core/src/main/scala-3/doobie/util/ReadPlatform.scala
@@ -4,67 +4,80 @@
 
 package doobie.util
 
+import doobie.util.shapeless.OrElse
+
 import scala.deriving.Mirror
 
 trait ReadPlatform {
 
   // Trivial Read for EmptyTuple
-  given Read[EmptyTuple] =
-    new Read[EmptyTuple](Nil, (_, _) => EmptyTuple)
+  given MkRead[EmptyTuple] =
+    new MkRead[EmptyTuple](Nil, (_, _) => EmptyTuple)
 
   // Read for head and tail.
-  given [H, T <: Tuple](using H: Read[H], T: Read[T]): Read[H *: T] =
-    new Read[H *: T](
-      H.gets ++ T.gets,
-      (rs, n) => H.unsafeGet(rs, n) *: T.unsafeGet(rs, n + H.length),
+  given [H, T <: Tuple](using
+    H: => Read[H] OrElse MkRead[H],
+    T: => MkRead[T],
+  ): MkRead[H *: T] = {
+    val head = H.unify
+
+    new MkRead[H *: T](
+      head.gets ++ T.gets,
+      (rs, n) => head.unsafeGet(rs, n) *: T.unsafeGet(rs, n + head.length),
     )
+  }
 
   // Generic Read for products.
-  given derived[P <: Product, A](
-    using
+  given [P <: Product, A](using
     m: Mirror.ProductOf[P],
     i: A =:= m.MirroredElemTypes,
-    w: Read[A],
-  ): Read[P] =
-    w.map(a => m.fromProduct(i(a)))
+    w: MkRead[A],
+  ): MkRead[P] = {
+    val read = w.map(a => m.fromProduct(i(a)))
+    MkRead.lift(read)
+  }
 
-  given roe: Read[Option[EmptyTuple]] =
-    new Read[Option[EmptyTuple]](Nil, (_, _) => Some(EmptyTuple))
+  given roe: MkRead[Option[EmptyTuple]] =
+    new MkRead[Option[EmptyTuple]](Nil, (_, _) => Some(EmptyTuple))
 
-  given rou: Read[Option[Unit]] =
-    new Read[Option[Unit]](Nil, (_, _) => Some(()))
+  given rou: MkRead[Option[Unit]] =
+    new MkRead[Option[Unit]](Nil, (_, _) => Some(()))
 
-  given cons1[H, T <: Tuple](
-    using
-    H: => Read[Option[H]],
-    T: => Read[Option[T]],
-  ): Read[Option[H *: T]] =
-    new Read[Option[H *: T]](
-      H.gets ++ T.gets,
+  given cons1[H, T <: Tuple](using
+    H: => Read[Option[H]] OrElse MkRead[Option[H]],
+    T: => MkRead[Option[T]],
+  ): MkRead[Option[H *: T]] = {
+    val head = H.unify
+
+    new MkRead[Option[H *: T]](
+      head.gets ++ T.gets,
       (rs, n) =>
         for {
-          h <- H.unsafeGet(rs, n)
-          t <- T.unsafeGet(rs, n + H.length)
+          h <- head.unsafeGet(rs, n)
+          t <- T.unsafeGet(rs, n + head.length)
         } yield h *: t,
     )
+  }
 
-  given cons2[H, T <: Tuple](
-    using
-    H: => Read[Option[H]],
-    T: => Read[Option[T]],
-  ): Read[Option[Option[H] *: T]] =
-    new Read[Option[Option[H] *: T]](
-      H.gets ++ T.gets,
-      (rs, n) => T.unsafeGet(rs, n + H.length).map(H.unsafeGet(rs, n) *: _),
+  given cons2[H, T <: Tuple](using
+    H: => Read[Option[H]] OrElse MkRead[Option[H]],
+    T: => MkRead[Option[T]],
+  ): MkRead[Option[Option[H] *: T]] = {
+    val head = H.unify
+
+    new MkRead[Option[Option[H] *: T]](
+      head.gets ++ T.gets,
+      (rs, n) => T.unsafeGet(rs, n + head.length).map(head.unsafeGet(rs, n) *: _),
     )
+  }
 
   // Generic Read for option of products.
-  given [P <: Product, A](
-    using
+  given [P <: Product, A](using
     m: Mirror.ProductOf[P],
     i: A =:= m.MirroredElemTypes,
-    w: Read[Option[A]],
-  ): Read[Option[P]] =
-    w.map(a => a.map(a => m.fromProduct(i(a))))
-
+    w: MkRead[Option[A]],
+  ): MkRead[Option[P]] = {
+    val read = w.map(a => a.map(a => m.fromProduct(i(a))))
+    MkRead.lift(read)
+  }
 }

--- a/modules/core/src/main/scala-3/doobie/util/WritePlatform.scala
+++ b/modules/core/src/main/scala-3/doobie/util/WritePlatform.scala
@@ -4,96 +4,105 @@
 
 package doobie.util
 
+import doobie.util.shapeless.OrElse
+
 import scala.deriving.Mirror
 
 trait WritePlatform {
 
   // Trivial write for empty tuple.
-  given Write[EmptyTuple] =
-    new Write(Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
+  given MkWrite[EmptyTuple] =
+    new MkWrite(Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
 
   // Inductive write for writable head and tail.
-  given [H, T <: Tuple](using H: => Write[H], T: => Write[T]): Write[H *: T] =
-    new Write(
-      H.puts ++ T.puts,
-      { case h *: t => H.toList(h) ++ T.toList(t) },
-      { case (ps, n, h *: t) => H.unsafeSet(ps, n, h); T.unsafeSet(ps, n + H.length, t) },
-      { case (rs, n, h *: t) => H.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + H.length, t) },
+  given [H, T <: Tuple](using
+    H: => Write[H] OrElse MkWrite[H],
+    T: => MkWrite[T],
+  ): MkWrite[H *: T] = {
+    val head = H.unify
+
+    new MkWrite(
+      head.puts ++ T.puts,
+      { case h *: t => head.toList(h) ++ T.toList(t) },
+      { case (ps, n, h *: t) => head.unsafeSet(ps, n, h); T.unsafeSet(ps, n + head.length, t) },
+      { case (rs, n, h *: t) => head.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + head.length, t) },
     )
+  }
 
   // Generic write for products.
-  given derived[P <: Product, A](
-    using
+  given derived[P <: Product, A](using
     m: Mirror.ProductOf[P],
     i: m.MirroredElemTypes =:= A,
-    w: Write[A],
-  ): Write[P] =
-    w.contramap(p => i(Tuple.fromProductTyped(p)))
+    w: MkWrite[A],
+  ): MkWrite[P] = {
+    val write: Write[P] = w.contramap(p => i(Tuple.fromProductTyped(p)))
+    MkWrite.lift(write)
+  }
 
   // Trivial write for option of empty tuple.
-  given woe: Write[Option[EmptyTuple]] =
-    new Write[Option[EmptyTuple]](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
+  given woe: MkWrite[Option[EmptyTuple]] =
+    new MkWrite[Option[EmptyTuple]](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
 
   // Trivial write for option of Unit.
-  given wou: Write[Option[Unit]] =
-    new Write[Option[Unit]](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
+  given wou: MkWrite[Option[Unit]] =
+    new MkWrite[Option[Unit]](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
 
   // Write[Option[H]], Write[Option[T]] implies Write[Option[H *: T]]
-  given cons1[H, T <: Tuple](
-    using
-    H: => Write[Option[H]],
-    T: => Write[Option[T]],
+  given cons1[H, T <: Tuple](using
+    H: => Write[Option[H]] OrElse MkWrite[Option[H]],
+    T: => MkWrite[Option[T]],
     // N: H <:!< Option[_],
-  ): Write[Option[H *: T]] = {
+  ): MkWrite[Option[H *: T]] = {
+    val head = H.unify
 
     def split[A](i: Option[H *: T])(f: (Option[H], Option[T]) => A): A =
       i.fold(f(None, None)) { case h *: t => f(Some(h), Some(t)) }
 
-    new Write(
-      H.puts ++ T.puts,
-      split(_) { (h, t) => H.toList(h) ++ T.toList(t) },
+    new MkWrite(
+      head.puts ++ T.puts,
+      split(_) { (h, t) => head.toList(h) ++ T.toList(t) },
       (ps, n, i) =>
         split(i) { (h, t) =>
-          H.unsafeSet(ps, n, h); T.unsafeSet(ps, n + H.length, t)
+          head.unsafeSet(ps, n, h); T.unsafeSet(ps, n + head.length, t)
         },
       (rs, n, i) =>
         split(i) { (h, t) =>
-          H.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + H.length, t)
+          head.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + head.length, t)
         },
     )
   }
 
   // Write[Option[H]], Write[Option[T]] implies Write[Option[Option[H] *: T]]
-  given cons2[H, T <: Tuple](
-    using
-    H: => Write[Option[H]],
-    T: => Write[Option[T]],
-  ): Write[Option[Option[H] *: T]] = {
+  given cons2[H, T <: Tuple](using
+    H: => Write[Option[H]] OrElse MkWrite[Option[H]],
+    T: => MkWrite[Option[T]],
+  ): MkWrite[Option[Option[H] *: T]] = {
+    val head = H.unify
 
     def split[A](i: Option[Option[H] *: T])(f: (Option[H], Option[T]) => A): A =
       i.fold(f(None, None)) { case oh *: t => f(oh, Some(t)) }
 
-    new Write(
-      H.puts ++ T.puts,
-      split(_) { (h, t) => H.toList(h) ++ T.toList(t) },
+    new MkWrite(
+      head.puts ++ T.puts,
+      split(_) { (h, t) => head.toList(h) ++ T.toList(t) },
       (ps, n, i) =>
         split(i) { (h, t) =>
-          H.unsafeSet(ps, n, h); T.unsafeSet(ps, n + H.length, t)
+          head.unsafeSet(ps, n, h); T.unsafeSet(ps, n + head.length, t)
         },
       (rs, n, i) =>
         split(i) { (h, t) =>
-          H.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + H.length, t)
+          head.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + head.length, t)
         },
     )
   }
 
   // Generic write for options of products.
-  given [P <: Product, A](
-    using
+  given [P <: Product, A](using
     m: Mirror.ProductOf[P],
     i: m.MirroredElemTypes =:= A,
-    w: Write[Option[A]],
-  ): Write[Option[P]] =
-    w.contramap(op => op.map(p => i(Tuple.fromProductTyped(p))))
-
+    w: MkWrite[Option[A]],
+  ): MkWrite[Option[P]] = {
+    val write: Write[Option[P]] = w.contramap(op => op.map(p => i(Tuple.fromProductTyped(p))))
+    MkWrite.lift(write)
+  }
 }

--- a/modules/core/src/main/scala-3/util/shapeless/OrElse.scala
+++ b/modules/core/src/main/scala-3/util/shapeless/OrElse.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.util.shapeless
+
+// from https://github.com/milessabin/shapeless/blob/v2.3.9/core/src/main/scala/shapeless/orelse.scala
+// for use from Scala 3
+
+/*
+ * Copyright (c) 2017 Georgi Krastev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Like `Option.orElse` on the type level and like `Either` on the value level.
+ *
+ * Instead of left and right constructors `OrElse` has primary and secondary
+ * implicits that lazily try to resolve first a value of type `A` or otherwise a
+ * value of type `B`.
+ */
+infix sealed trait OrElse[+A, +B] {
+  def fold[C](prim: A => C, sec: B => C): C
+  def unify[C >: A](implicit ev: B <:< C): C = fold(a => a, ev)
+}
+
+final class Primary[+A](value: A) extends OrElse[A, Nothing] {
+  def fold[C](prim: A => C, sec: Nothing => C) = prim(value)
+}
+
+final class Secondary[+B](value: => B) extends OrElse[Nothing, B] {
+  def fold[C](prim: Nothing => C, sec: B => C) = sec(value)
+}
+
+object OrElse extends OrElse0 {
+  implicit def primary[A, B](implicit a: A): A OrElse B = new Primary(a)
+}
+
+private[shapeless] abstract class OrElse0 {
+  implicit def secondary[A, B](implicit b: => B): A OrElse B = new Secondary(b)
+}

--- a/modules/core/src/main/scala/doobie/generic/auto.scala
+++ b/modules/core/src/main/scala/doobie/generic/auto.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.generic
+
+import doobie.util.Get
+import doobie.util.Put
+import doobie.util.Read
+import doobie.util.Write
+import doobie.util.meta.Meta
+
+trait AutoDerivation
+  extends Get.Auto
+  with Put.Auto
+  with Read.Auto
+  with Write.Auto
+
+object auto extends AutoDerivation {
+
+  // re-export these instances so `Meta` takes priority, must be in the object
+  implicit def metaProjectionGet[A](implicit m: Meta[A]): Get[A] = Get.metaProjection
+  implicit def metaProjectionPut[A](implicit m: Meta[A]): Put[A] = Put.metaProjectionWrite
+  implicit def fromGetRead[A](implicit G: Get[A]): Read[A] = Read.fromGet
+  implicit def fromPutWrite[A](implicit P: Put[A]): Write[A] = Write.fromPut
+}

--- a/modules/core/src/main/scala/doobie/package.scala
+++ b/modules/core/src/main/scala/doobie/package.scala
@@ -100,6 +100,15 @@ package object doobie {
 
   val ExecutionContexts = doobie.util.ExecutionContexts
 
-  object implicits extends syntax.AllSyntax
+  object implicits
+    extends syntax.AllSyntax
+    with generic.AutoDerivation {
+
+    // re-export these instances so `Meta` takes priority, must be in the object
+    implicit def metaProjectionGet[A](implicit m: Meta[A]): Get[A] = Get.metaProjection
+    implicit def metaProjectionPut[A](implicit m: Meta[A]): Put[A] = Put.metaProjectionWrite
+    implicit def fromGetRead[A](implicit G: Get[A]): Read[A] = Read.fromGet
+    implicit def fromPutWrite[A](implicit P: Put[A]): Write[A] = Write.fromPut
+  }
 
 }

--- a/modules/core/src/main/scala/doobie/util/analysis.scala
+++ b/modules/core/src/main/scala/doobie/util/analysis.scala
@@ -172,20 +172,18 @@ object analysis {
 
     def columnTypeErrors: List[ColumnTypeError] =
       columnAlignment_.zipWithIndex.collect {
-        case (Ior.Both((j, n1), p), n)
-            if !(j.jdbcSources.toList ++ j.fold(_.jdbcSourceSecondary.toList, _ => Nil)).contains_(p.jdbcType) =>
+        case (Ior.Both((j, n1), p), n) if !(j.jdbcSources.toList ++ j.jdbcSourceSecondary).contains_(p.jdbcType) =>
           ColumnTypeError(n + 1, j, n1, p)
         case (Ior.Both((j, n1), p), n)
-            if (p.jdbcType === JdbcType.JavaObject || p.jdbcType === JdbcType.Other) && !j.fold(
-              _ => None,
-              a => Some(a.schemaTypes.head),
-            ).contains_(p.vendorTypeName) =>
+            if (p.jdbcType === JdbcType.JavaObject || p.jdbcType === JdbcType.Other) && !j.schemaTypes.headOption.contains_(
+              p.vendorTypeName,
+            ) =>
           ColumnTypeError(n + 1, j, n1, p)
       }
 
     def columnTypeWarnings: List[ColumnTypeWarning] =
       columnAlignment_.zipWithIndex.collect {
-        case (Ior.Both((j, n1), p), n) if j.fold(_.jdbcSourceSecondary.toList, _ => Nil).contains_(p.jdbcType) =>
+        case (Ior.Both((j, n1), p), n) if j.jdbcSourceSecondary.contains_(p.jdbcType) =>
           ColumnTypeWarning(n + 1, j, n1, p)
       }
 

--- a/modules/core/src/main/scala/doobie/util/fragment.scala
+++ b/modules/core/src/main/scala/doobie/util/fragment.scala
@@ -82,7 +82,7 @@ object fragment {
         }
       }
 
-      new Write(puts, toList, unsafeSet, unsafeUpdate)
+      Write(puts, toList, unsafeSet, unsafeUpdate)
 
     }
 

--- a/modules/core/src/main/scala/doobie/util/get.scala
+++ b/modules/core/src/main/scala/doobie/util/get.scala
@@ -21,16 +21,15 @@ import scala.reflect.ClassTag
 sealed abstract class Get[A](
   val typeStack: NonEmptyList[Option[String]],
   val jdbcSources: NonEmptyList[JdbcType],
+  val jdbcSourceSecondary: List[JdbcType],
+  val schemaTypes: List[String],
   val get: Coyoneda[(ResultSet, Int) => *, A],
 ) {
-
-  protected def mapImpl[B](f: A => B, typ: Option[String]): Get[B]
 
   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   final def unsafeGetNonNullable(rs: ResultSet, n: Int): A = {
     val i = get.fi(rs, n)
-    if (rs.wasNull)
-      throw NonNullableColumnRead(n, jdbcSources.head)
+    if (rs.wasNull) throw NonNullableColumnRead(n, jdbcSources.head)
     get.k(i)
   }
 
@@ -56,6 +55,15 @@ sealed abstract class Get[A](
   final def tmap[B](f: A => B)(implicit ev: TypeName[B]): Get[B] =
     mapImpl(f, Some(ev.value))
 
+  private def mapImpl[B](f: A => B, typ: Option[String]): Get[B] =
+    new Get[B](
+      typeStack = typ :: typeStack,
+      jdbcSources = jdbcSources,
+      jdbcSourceSecondary = jdbcSourceSecondary,
+      schemaTypes = schemaTypes,
+      get = get.map(f),
+    ) {}
+
   /**
    * Equivalent to `tmap`, but allows the conversion to fail with an error
    * message.
@@ -69,80 +77,82 @@ sealed abstract class Get[A](
       }
     }
 
-  def fold[B](f: Get.Basic[A] => B, g: Get.Advanced[A] => B): B
-
 }
 
 object Get extends GetInstances {
 
   def apply[A](implicit ev: Get[A]): ev.type = ev
 
-  /** Get instance for a basic JDBC type. */
-  final case class Basic[A](
-    override val typeStack: NonEmptyList[Option[String]],
-    override val jdbcSources: NonEmptyList[JdbcType],
-    val jdbcSourceSecondary: List[JdbcType],
-    override val get: Coyoneda[(ResultSet, Int) => *, A],
-  ) extends Get[A](typeStack, jdbcSources, get) {
+  def derived[A](implicit ev: MkGet[A]): Get[A] = ev
 
-    protected def mapImpl[B](f: A => B, typ: Option[String]): Get[B] =
-      copy(get = get.map(f), typeStack = typ :: typeStack)
-
-    def fold[B](f: Get.Basic[A] => B, g: Get.Advanced[A] => B): B =
-      f(this)
-
+  trait Auto {
+    implicit def deriveGet[A](implicit ev: MkGet[A]): Get[A] = ev
   }
+
+  /** Get instance for a basic JDBC type. */
   object Basic {
+
+    def apply[A](
+      typeStack: NonEmptyList[Option[String]],
+      jdbcSources: NonEmptyList[JdbcType],
+      jdbcSourceSecondary: List[JdbcType],
+      get: Coyoneda[(ResultSet, Int) => *, A],
+    ): Get[A] = new Get[A](
+      typeStack,
+      jdbcSources = jdbcSources,
+      jdbcSourceSecondary = jdbcSourceSecondary,
+      schemaTypes = Nil,
+      get,
+    ) {}
 
     def many[A](
       jdbcSources: NonEmptyList[JdbcType],
       jdbcSourceSecondary: List[JdbcType],
       get: (ResultSet, Int) => A,
-    )(implicit ev: TypeName[A]): Basic[A] =
+    )(implicit ev: TypeName[A]): Get[A] =
       Basic(NonEmptyList.of(Some(ev.value)), jdbcSources, jdbcSourceSecondary, Coyoneda.lift(get))
 
     def one[A: TypeName](
       jdbcSources: JdbcType,
       jdbcSourceSecondary: List[JdbcType],
       get: (ResultSet, Int) => A,
-    ): Basic[A] =
+    ): Get[A] =
       many(NonEmptyList.of(jdbcSources), jdbcSourceSecondary, get)
 
   }
 
   /** Get instance for an advanced JDBC type. */
-  final case class Advanced[A](
-    override val typeStack: NonEmptyList[Option[String]],
-    override val jdbcSources: NonEmptyList[JdbcType],
-    val schemaTypes: NonEmptyList[String],
-    override val get: Coyoneda[(ResultSet, Int) => *, A],
-  ) extends Get[A](typeStack, jdbcSources, get) {
-
-    protected def mapImpl[B](f: A => B, typ: Option[String]): Get[B] =
-      copy(get = get.map(f), typeStack = typ :: typeStack)
-
-    def fold[B](f: Get.Basic[A] => B, g: Get.Advanced[A] => B): B =
-      g(this)
-
-  }
   object Advanced {
+
+    def apply[A](
+      typeStack: NonEmptyList[Option[String]],
+      jdbcSources: NonEmptyList[JdbcType],
+      schemaTypes: NonEmptyList[String],
+      get: Coyoneda[(ResultSet, Int) => *, A],
+    ): Get[A] = new Get[A](
+      typeStack,
+      jdbcSources = jdbcSources,
+      jdbcSourceSecondary = Nil,
+      schemaTypes = schemaTypes.toList,
+      get,
+    ) {}
 
     def many[A](
       jdbcSources: NonEmptyList[JdbcType],
       schemaTypes: NonEmptyList[String],
       get: (ResultSet, Int) => A,
-    )(implicit ev: TypeName[A]): Advanced[A] =
+    )(implicit ev: TypeName[A]): Get[A] =
       Advanced(NonEmptyList.of(Some(ev.value)), jdbcSources, schemaTypes, Coyoneda.lift(get))
 
     def one[A](
       jdbcSource: JdbcType,
       schemaTypes: NonEmptyList[String],
       get: (ResultSet, Int) => A,
-    )(implicit ev: TypeName[A]): Advanced[A] =
+    )(implicit ev: TypeName[A]): Get[A] =
       Advanced(NonEmptyList.of(Some(ev.value)), NonEmptyList.of(jdbcSource), schemaTypes, Coyoneda.lift(get))
 
     @SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.AsInstanceOf"))
-    def array[A >: Null <: AnyRef](schemaTypes: NonEmptyList[String]): Advanced[Array[A]] =
+    def array[A >: Null <: AnyRef](schemaTypes: NonEmptyList[String]): Get[Array[A]] =
       one(
         JdbcType.Array,
         schemaTypes,
@@ -155,7 +165,7 @@ object Get extends GetInstances {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf", "org.wartremover.warts.Throw"))
     def other[A >: Null <: AnyRef: TypeName](schemaTypes: NonEmptyList[String])(
       implicit A: ClassTag[A],
-    ): Advanced[A] =
+    ): Get[A] =
       many(
         NonEmptyList.of(JdbcType.Other, JdbcType.JavaObject),
         schemaTypes,
@@ -182,7 +192,7 @@ object Get extends GetInstances {
 
 }
 
-trait GetInstances extends GetPlatform {
+trait GetInstances {
 
   /** @group Instances */
   implicit val FunctorGet: Functor[Get] =
@@ -199,4 +209,17 @@ trait GetInstances extends GetPlatform {
   implicit def ArrayTypeAsVectorGet[A](implicit ev: Get[Array[A]]): Get[Vector[A]] =
     ev.tmap(_.toVector)
 
+}
+
+sealed abstract class MkGet[A](
+  override val typeStack: NonEmptyList[Option[String]],
+  override val jdbcSources: NonEmptyList[JdbcType],
+  override val jdbcSourceSecondary: List[JdbcType],
+  override val schemaTypes: List[String],
+  override val get: Coyoneda[(ResultSet, Int) => *, A],
+) extends Get[A](typeStack, jdbcSources, jdbcSourceSecondary, schemaTypes, get)
+object MkGet extends GetPlatform {
+
+  def lift[A](g: Get[A]): MkGet[A] =
+    new MkGet[A](g.typeStack, g.jdbcSources, g.jdbcSourceSecondary, g.schemaTypes, g.get) {}
 }

--- a/modules/core/src/main/scala/doobie/util/io.scala
+++ b/modules/core/src/main/scala/doobie/util/io.scala
@@ -4,7 +4,7 @@
 
 package doobie.util
 
-import cats.effect.implicits.monadCancelOps_
+import cats.effect.syntax.monadCancel.*
 import cats.syntax.applicative.*
 import cats.syntax.flatMap.*
 import cats.syntax.functor.*

--- a/modules/core/src/main/scala/doobie/util/put.scala
+++ b/modules/core/src/main/scala/doobie/util/put.scala
@@ -18,19 +18,34 @@ import scala.reflect.ClassTag
 sealed abstract class Put[A](
   val typeStack: NonEmptyList[Option[String]],
   val jdbcTargets: NonEmptyList[JdbcType],
+  val schemaTypes: List[String],
   val put: ContravariantCoyoneda[(PreparedStatement, Int, *) => Unit, A],
   val update: ContravariantCoyoneda[(ResultSet, Int, *) => Unit, A],
 ) {
 
-  protected def contramapImpl[B](f: B => A, typ: Option[String]): Put[B]
+  def unsafeSetNull(ps: PreparedStatement, n: Int): Unit = {
+    val sqlType = jdbcTargets.head.toInt
 
-  def unsafeSetNull(ps: PreparedStatement, n: Int): Unit
+    schemaTypes.headOption match {
+      case None => ps.setNull(n, sqlType)
+      case Some(schemaType) => ps.setNull(n, sqlType, schemaType)
+    }
+  }
 
   final def contramap[B](f: B => A): Put[B] =
     contramapImpl(f, None)
 
   final def tcontramap[B](f: B => A)(implicit ev: TypeName[B]): Put[B] =
     contramapImpl(f, Some(ev.value))
+
+  private def contramapImpl[B](f: B => A, typ: Option[String]): Put[B] =
+    new Put[B](
+      typeStack = typ :: typeStack,
+      jdbcTargets = jdbcTargets,
+      schemaTypes = schemaTypes,
+      put = put.contramap(f),
+      update = update.contramap(f),
+    ) {}
 
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   def unsafeSetNonNullable(ps: PreparedStatement, n: Int, a: A): Unit =
@@ -60,28 +75,26 @@ object Put extends PutInstances {
 
   def apply[A](implicit ev: Put[A]): ev.type = ev
 
-  final case class Basic[A](
-    override val typeStack: NonEmptyList[Option[String]],
-    override val jdbcTargets: NonEmptyList[JdbcType],
-    override val put: ContravariantCoyoneda[(PreparedStatement, Int, *) => Unit, A],
-    override val update: ContravariantCoyoneda[(ResultSet, Int, *) => Unit, A],
-  ) extends Put[A](typeStack, jdbcTargets, put, update) {
+  def derived[A](implicit ev: MkPut[A]): Put[A] = ev
 
-    protected def contramapImpl[B](f: B => A, typ: Option[String]): Put[B] =
-      copy(typeStack = typ :: typeStack, update = update.contramap(f), put = put.contramap(f))
-
-    def unsafeSetNull(ps: PreparedStatement, n: Int): Unit =
-      ps.setNull(n, jdbcTargets.head.toInt)
-
+  trait Auto {
+    implicit def derivePut[A](implicit ev: MkPut[A]): Put[A] = ev
   }
 
   object Basic {
+
+    def apply[A](
+      typeStack: NonEmptyList[Option[String]],
+      jdbcTargets: NonEmptyList[JdbcType],
+      put: ContravariantCoyoneda[(PreparedStatement, Int, *) => Unit, A],
+      update: ContravariantCoyoneda[(ResultSet, Int, *) => Unit, A],
+    ): Put[A] = new Put[A](typeStack, jdbcTargets, schemaTypes = Nil, put, update) {}
 
     def many[A](
       jdbcTargets: NonEmptyList[JdbcType],
       put: (PreparedStatement, Int, A) => Unit,
       update: (ResultSet, Int, A) => Unit,
-    )(implicit ev: TypeName[A]): Basic[A] =
+    )(implicit ev: TypeName[A]): Put[A] =
       Basic(
         NonEmptyList.of(Some(ev.value)),
         jdbcTargets,
@@ -93,34 +106,27 @@ object Put extends PutInstances {
       jdbcTarget: JdbcType,
       put: (PreparedStatement, Int, A) => Unit,
       update: (ResultSet, Int, A) => Unit,
-    )(implicit ev: TypeName[A]): Basic[A] =
+    )(implicit ev: TypeName[A]): Put[A] =
       many(NonEmptyList.of(jdbcTarget), put, update)
 
   }
 
-  final case class Advanced[A](
-    override val typeStack: NonEmptyList[Option[String]],
-    override val jdbcTargets: NonEmptyList[JdbcType],
-    val schemaTypes: NonEmptyList[String],
-    override val put: ContravariantCoyoneda[(PreparedStatement, Int, *) => Unit, A],
-    override val update: ContravariantCoyoneda[(ResultSet, Int, *) => Unit, A],
-  ) extends Put[A](typeStack, jdbcTargets, put, update) {
-
-    protected def contramapImpl[B](f: B => A, typ: Option[String]): Put[B] =
-      copy(typeStack = typ :: typeStack, update = update.contramap(f), put = put.contramap(f))
-
-    def unsafeSetNull(ps: PreparedStatement, n: Int): Unit =
-      ps.setNull(n, jdbcTargets.head.toInt, schemaTypes.head)
-
-  }
   object Advanced {
+
+    def apply[A](
+      typeStack: NonEmptyList[Option[String]],
+      jdbcTargets: NonEmptyList[JdbcType],
+      schemaTypes: NonEmptyList[String],
+      put: ContravariantCoyoneda[(PreparedStatement, Int, *) => Unit, A],
+      update: ContravariantCoyoneda[(ResultSet, Int, *) => Unit, A],
+    ): Put[A] = new Put[A](typeStack, jdbcTargets, schemaTypes.toList, put, update) {}
 
     def many[A](
       jdbcTargets: NonEmptyList[JdbcType],
       schemaTypes: NonEmptyList[String],
       put: (PreparedStatement, Int, A) => Unit,
       update: (ResultSet, Int, A) => Unit,
-    )(implicit ev: TypeName[A]): Advanced[A] =
+    )(implicit ev: TypeName[A]): Put[A] =
       Advanced(
         NonEmptyList.of(Some(ev.value)),
         jdbcTargets,
@@ -134,14 +140,14 @@ object Put extends PutInstances {
       schemaTypes: NonEmptyList[String],
       put: (PreparedStatement, Int, A) => Unit,
       update: (ResultSet, Int, A) => Unit,
-    ): Advanced[A] =
+    ): Put[A] =
       many(NonEmptyList.of(jdbcTarget), schemaTypes, put, update)
 
     @SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.AsInstanceOf"))
     def array[A >: Null <: AnyRef](
       schemaTypes: NonEmptyList[String],
       elementType: String,
-    ): Advanced[Array[A]] =
+    ): Put[Array[A]] =
       one(
         JdbcType.Array,
         schemaTypes,
@@ -158,7 +164,7 @@ object Put extends PutInstances {
         },
       )
 
-    def other[A >: Null <: AnyRef: TypeName](schemaTypes: NonEmptyList[String]): Advanced[A] =
+    def other[A >: Null <: AnyRef: TypeName](schemaTypes: NonEmptyList[String]): Put[A] =
       many(
         NonEmptyList.of(JdbcType.Other, JdbcType.JavaObject),
         schemaTypes,
@@ -176,7 +182,7 @@ object Put extends PutInstances {
 
 }
 
-trait PutInstances extends PutPlatform {
+trait PutInstances {
 
   /** @group Instances */
   implicit val ContravariantPut: Contravariant[Put] =
@@ -193,4 +199,17 @@ trait PutInstances extends PutPlatform {
   implicit def ArrayTypeAsVectorPut[A: ClassTag](implicit ev: Put[Array[A]]): Put[Vector[A]] =
     ev.tcontramap(_.toArray)
 
+}
+
+sealed abstract class MkPut[A](
+  override val typeStack: NonEmptyList[Option[String]],
+  override val jdbcTargets: NonEmptyList[JdbcType],
+  override val schemaTypes: List[String],
+  override val put: ContravariantCoyoneda[(PreparedStatement, Int, *) => Unit, A],
+  override val update: ContravariantCoyoneda[(ResultSet, Int, *) => Unit, A],
+) extends Put[A](typeStack, jdbcTargets, schemaTypes, put, update)
+object MkPut extends PutPlatform {
+
+  def lift[A](g: Put[A]): MkPut[A] =
+    new MkPut[A](g.typeStack, g.jdbcTargets, g.schemaTypes, g.put, g.update) {}
 }

--- a/modules/core/src/main/scala/doobie/util/read.scala
+++ b/modules/core/src/main/scala/doobie/util/read.scala
@@ -21,6 +21,8 @@ This can happen for a few reasons, but the most common case is that a data
 member somewhere within this type doesn't have a Get instance in scope. Here are
 some debugging hints:
 
+- For auto derivation ensure `doobie.implicits._` or `doobie.generic.auto._` is
+  being imported
 - For Option types, ensure that a Read instance is in scope for the non-Option
   version.
 - For types you expect to map to a single column ensure that a Get instance is
@@ -40,7 +42,7 @@ and similarly with Get:
 And find the missing instance and construct it as needed. Refer to Chapter 12
 of the book of doobie for more information.
 """)
-final class Read[A](
+sealed abstract class Read[A](
   val gets: List[(Get[?], NullabilityKnown)],
   val unsafeGet: (ResultSet, Int) => A,
 ) {
@@ -48,34 +50,54 @@ final class Read[A](
   final lazy val length: Int = gets.length
 
   def map[B](f: A => B): Read[B] =
-    new Read(gets, (rs, n) => f(unsafeGet(rs, n)))
+    new Read(gets, (rs, n) => f(unsafeGet(rs, n))) {}
 
   def ap[B](ff: Read[A => B]): Read[B] =
-    new Read(ff.gets ++ gets, (rs, n) => ff.unsafeGet(rs, n)(unsafeGet(rs, n + ff.length)))
+    new Read(ff.gets ++ gets, (rs, n) => ff.unsafeGet(rs, n)(unsafeGet(rs, n + ff.length))) {}
 
   def get(n: Int): ResultSetIO[A] =
     FRS.raw(unsafeGet(_, n))
 
 }
 
-object Read extends ReadPlatform {
+object Read {
+
+  def apply[A](
+    gets: List[(Get[?], NullabilityKnown)],
+    unsafeGet: (ResultSet, Int) => A,
+  ): Read[A] = new Read(gets, unsafeGet) {}
 
   def apply[A](implicit ev: Read[A]): ev.type = ev
+
+  def derived[A](implicit ev: MkRead[A]): Read[A] = ev
+
+  trait Auto {
+    implicit def deriveRead[A](implicit ev: MkRead[A]): Read[A] = ev
+  }
 
   implicit val ReadApply: Applicative[Read] =
     new Applicative[Read] {
       def ap[A, B](ff: Read[A => B])(fa: Read[A]): Read[B] = fa.ap(ff)
-      def pure[A](x: A): Read[A] = new Read(Nil, (_, _) => x)
+      def pure[A](x: A): Read[A] = new Read(Nil, (_, _) => x) {}
       override def map[A, B](fa: Read[A])(f: A => B): Read[B] = fa.map(f)
     }
 
   implicit val unit: Read[Unit] =
-    new Read(Nil, (_, _) => ())
+    new Read(Nil, (_, _) => ()) {}
 
   implicit def fromGet[A](implicit ev: Get[A]): Read[A] =
-    new Read(List((ev, NoNulls)), ev.unsafeGetNonNullable)
+    new Read(List((ev, NoNulls)), ev.unsafeGetNonNullable) {}
 
   implicit def fromGetOption[A](implicit ev: Get[A]): Read[Option[A]] =
-    new Read(List((ev, Nullable)), ev.unsafeGetNullable)
+    new Read(List((ev, Nullable)), ev.unsafeGetNullable) {}
 
+}
+
+final class MkRead[A](
+  override val gets: List[(Get[?], NullabilityKnown)],
+  override val unsafeGet: (ResultSet, Int) => A,
+) extends Read[A](gets, unsafeGet)
+object MkRead extends ReadPlatform {
+
+  def lift[A](r: Read[A]): MkRead[A] = new MkRead[A](r.gets, r.unsafeGet)
 }

--- a/modules/core/src/test/scala-2/doobie/util/GetSuitePlatform.scala
+++ b/modules/core/src/test/scala-2/doobie/util/GetSuitePlatform.scala
@@ -12,9 +12,16 @@ object GetSuitePlatform {
 trait GetSuitePlatform { self: munit.FunSuite =>
   import GetSuitePlatform.*
 
-  test("Get should be derived for unary products (AnyVal)") {
+  test("Get can be auto derived for unary products (AnyVal)") {
+    import doobie.generic.auto.*
+
     Get[Y]: Unit
     Get[P]: Unit
+  }
+
+  test("Get can be explicitly derived for unary products (AnyVal)") {
+    Get.derived[Y]: Unit
+    Get.derived[P]: Unit
   }
 
 }

--- a/modules/core/src/test/scala-2/doobie/util/LogSuitePlatform.scala
+++ b/modules/core/src/test/scala-2/doobie/util/LogSuitePlatform.scala
@@ -9,6 +9,7 @@ import doobie.util.log.Success
 import shapeless.*
 
 trait LogSuitePlatform { self: LogSuite =>
+  import doobie.generic.auto.*
 
   test("[Query] n-arg success") {
     val Sql = "select 1 where ? = ?"

--- a/modules/core/src/test/scala-2/doobie/util/PutSuitePlatform.scala
+++ b/modules/core/src/test/scala-2/doobie/util/PutSuitePlatform.scala
@@ -12,9 +12,16 @@ object PutSuitePlatform {
 trait PutSuitePlatform { self: munit.FunSuite =>
   import PutSuitePlatform.*
 
-  test("Put should be derived for unary products (AnyVal)") {
+  test("Put can be auto derived for unary products (AnyVal)") {
+    import doobie.generic.auto.*
+
     Put[Y]: Unit
     Put[P]: Unit
+  }
+
+  test("Put can be explicitly derived for unary products (AnyVal)") {
+    Put.derived[Y]: Unit
+    Put.derived[P]: Unit
   }
 
 }

--- a/modules/core/src/test/scala-2/doobie/util/ReadSuitePlatform.scala
+++ b/modules/core/src/test/scala-2/doobie/util/ReadSuitePlatform.scala
@@ -2,8 +2,7 @@
 // This software is licensed under the MIT License (MIT).
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
-package doobie
-package util
+package doobie.util
 
 import shapeless.*
 import shapeless.record.*
@@ -11,26 +10,27 @@ import shapeless.record.*
 import scala.annotation.nowarn
 
 trait ReadSuitePlatform { self: munit.FunSuite =>
+  import doobie.generic.auto.*
 
   test("Read should exist for shapeless record types") {
     type DL = (Double, Long) // used below
     type A = Record.`'foo -> Int, 'bar -> String, 'baz -> DL, 'quz -> Woozle`.T
-    util.Read[A]: Unit
-    util.Read[(A, A)]: Unit
+    Read[A]: Unit
+    Read[(A, A)]: Unit
   }: @nowarn("msg=.*DL is never used.*")
 
   case class Woozle(a: (String, Int), b: Int :: String :: HNil, c: Boolean)
 
   test("Read should exist for some fancy types") {
-    util.Read[Woozle]: Unit
-    util.Read[(Woozle, String)]: Unit
-    util.Read[(Int, Woozle :: Woozle :: String :: HNil)]: Unit
+    Read[Woozle]: Unit
+    Read[(Woozle, String)]: Unit
+    Read[(Int, Woozle :: Woozle :: String :: HNil)]: Unit
   }
 
   test("Read should exist for option of some fancy types") {
-    util.Read[Option[Woozle]]: Unit
-    util.Read[Option[(Woozle, String)]]: Unit
-    util.Read[Option[(Int, Woozle :: Woozle :: String :: HNil)]]: Unit
+    Read[Option[Woozle]]: Unit
+    Read[Option[(Woozle, String)]]: Unit
+    Read[Option[(Int, Woozle :: Woozle :: String :: HNil)]]: Unit
   }
 
 }

--- a/modules/core/src/test/scala-2/doobie/util/WriteSuitePlatform.scala
+++ b/modules/core/src/test/scala-2/doobie/util/WriteSuitePlatform.scala
@@ -2,8 +2,7 @@
 // This software is licensed under the MIT License (MIT).
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
-package doobie
-package util
+package doobie.util
 
 import shapeless.*
 import shapeless.record.*
@@ -11,26 +10,27 @@ import shapeless.record.*
 import scala.annotation.nowarn
 
 trait WriteSuitePlatform { self: munit.FunSuite =>
+  import doobie.generic.auto.*
 
   test("Write should exist for shapeless record types") {
     type DL = (Double, Long)
     type A = Record.`'foo -> Int, 'bar -> String, 'baz -> DL, 'quz -> Woozle`.T
-    util.Write[A]: Unit
-    util.Write[(A, A)]: Unit
+    Write[A]: Unit
+    Write[(A, A)]: Unit
   }: @nowarn("msg=.*DL is never used.*")
 
   case class Woozle(a: (String, Int), b: Int :: String :: HNil, c: Boolean)
 
   test("Write should exist for some fancy types") {
-    util.Write[Woozle]: Unit
-    util.Write[(Woozle, String)]: Unit
-    util.Write[(Int, Woozle :: Woozle :: String :: HNil)]: Unit
+    Write[Woozle]: Unit
+    Write[(Woozle, String)]: Unit
+    Write[(Int, Woozle :: Woozle :: String :: HNil)]: Unit
   }
 
   test("Write should exist for option of some fancy types") {
-    util.Write[Option[Woozle]]: Unit
-    util.Write[Option[(Woozle, String)]]: Unit
-    util.Write[Option[(Int, Woozle :: Woozle :: String :: HNil)]]: Unit
+    Write[Option[Woozle]]: Unit
+    Write[Option[(Woozle, String)]]: Unit
+    Write[Option[(Int, Woozle :: Woozle :: String :: HNil)]]: Unit
   }
 
 }

--- a/modules/core/src/test/scala-3/doobie/util/LogSuitePlatform.scala
+++ b/modules/core/src/test/scala-3/doobie/util/LogSuitePlatform.scala
@@ -8,6 +8,7 @@ import doobie.util.log.ProcessingFailure
 import doobie.util.log.Success
 
 trait LogSuitePlatform { self: LogSuite =>
+  import doobie.generic.auto.*
 
   test("[Query] n-arg success") {
     val Sql = "select 1 where ? = ?"

--- a/modules/core/src/test/scala-3/doobie/util/ReadSuitePlatform.scala
+++ b/modules/core/src/test/scala-3/doobie/util/ReadSuitePlatform.scala
@@ -2,26 +2,29 @@
 // This software is licensed under the MIT License (MIT).
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
-package doobie
-package util
+package doobie.util
 
 trait ReadSuitePlatform { self: munit.FunSuite =>
 
   case class Woozle(a: (String, Int), b: Int *: String *: EmptyTuple, c: Boolean)
 
   test("Read should exist for some fancy types") {
-    util.Read[Woozle]
-    util.Read[(Woozle, String)]
-    util.Read[(Int, Woozle *: Woozle *: String *: EmptyTuple)]
+    import doobie.generic.auto.*
+
+    Read[Woozle]
+    Read[(Woozle, String)]
+    Read[(Int, Woozle *: Woozle *: String *: EmptyTuple)]
   }
 
   test("Read should exist for option of some fancy types") {
-    util.Read[Option[Woozle]]
-    util.Read[Option[(Woozle, String)]]
-    util.Read[Option[(Int, Woozle *: Woozle *: String *: EmptyTuple)]]
+    import doobie.generic.auto.*
+
+    Read[Option[Woozle]]
+    Read[Option[(Woozle, String)]]
+    Read[Option[(Int, Woozle *: Woozle *: String *: EmptyTuple)]]
   }
 
   test("derives") {
-    case class Foo(a: String, b: Int) derives util.Read
+    case class Foo(a: String, b: Int) derives Read
   }
 }

--- a/modules/core/src/test/scala-3/doobie/util/WriteSuitePlatform.scala
+++ b/modules/core/src/test/scala-3/doobie/util/WriteSuitePlatform.scala
@@ -2,26 +2,29 @@
 // This software is licensed under the MIT License (MIT).
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
-package doobie
-package util
+package doobie.util
 
 trait WriteSuitePlatform { self: munit.FunSuite =>
 
   case class Woozle(a: (String, Int), b: Int *: String *: EmptyTuple, c: Boolean)
 
   test("Write should exist for some fancy types") {
-    util.Write[Woozle]
-    util.Write[(Woozle, String)]
-    util.Write[(Int, Woozle *: Woozle *: String *: EmptyTuple)]
+    import doobie.generic.auto.*
+
+    Write[Woozle]
+    Write[(Woozle, String)]
+    Write[(Int, Woozle *: Woozle *: String *: EmptyTuple)]
   }
 
   test("Write should exist for option of some fancy types") {
-    util.Write[Option[Woozle]]
-    util.Write[Option[(Woozle, String)]]
-    util.Write[Option[(Int, Woozle *: Woozle *: String *: EmptyTuple)]]
+    import doobie.generic.auto.*
+
+    Write[Option[Woozle]]
+    Write[Option[(Woozle, String)]]
+    Write[Option[(Int, Woozle *: Woozle *: String *: EmptyTuple)]]
   }
 
   test("derives") {
-    case class Foo(a: String, b: Int) derives util.Write
+    case class Foo(a: String, b: Int) derives Write
   }
 }

--- a/modules/core/src/test/scala/doobie/issue/780.scala
+++ b/modules/core/src/test/scala/doobie/issue/780.scala
@@ -10,6 +10,7 @@ import scala.annotation.nowarn
 
 @nowarn("msg=.*Foo is never used.*")
 class `780` extends munit.FunSuite {
+  import doobie.generic.auto.*
 
   test("deriving instances should work correctly for Write from class scope") {
     class Foo[A: Write, B: Write] {

--- a/modules/core/src/test/scala/doobie/syntax/StringSuite.scala
+++ b/modules/core/src/test/scala/doobie/syntax/StringSuite.scala
@@ -7,6 +7,7 @@ package doobie.syntax
 import doobie.syntax.string.*
 
 class StringSuite extends munit.FunSuite {
+  import doobie.generic.auto.*
 
   test("sql interpolator should support no-param queries") {
     val q = sql"foo bar baz".query[Int]

--- a/modules/core/src/test/scala/doobie/util/FragmentSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/FragmentSuite.scala
@@ -12,8 +12,8 @@ import doobie.util.fragment.Fragment
 import doobie.util.transactor.Transactor
 
 class FragmentSuite extends munit.FunSuite {
-
   import cats.effect.unsafe.implicits.global
+  import doobie.generic.auto.*
 
   val xa = Transactor.fromDriverManager[IO](
     "org.h2.Driver",

--- a/modules/core/src/test/scala/doobie/util/FragmentsSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/FragmentsSuite.scala
@@ -13,6 +13,7 @@ import doobie.util.transactor.Transactor
 
 class FragmentsSuite extends munit.FunSuite {
   import cats.effect.unsafe.implicits.global
+  import doobie.generic.auto.*
   import doobie.util.fragments.*
 
   val xa = Transactor.fromDriverManager[IO](

--- a/modules/core/src/test/scala/doobie/util/LogSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/LogSuite.scala
@@ -34,13 +34,11 @@ class LogSuite extends munit.FunSuite {
   def eventForCIO[A](cio: ConnectionIO[A]): LogEvent =
     cio.transact(xa).attempt.flatMap(_ => ioLocal.get).unsafeRunSync()
 
-  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-  def eventForUniqueQuery[A: Write](sql: String, arg: A = ()): LogEvent = {
+  def eventForUniqueQuery[A: Write](sql: String, arg: A): LogEvent = {
     eventForCIO(Query[A, Unit](sql, None).unique(arg))
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-  def eventForUniqueUpdate[A: Write](sql: String, arg: A = ()): LogEvent = {
+  def eventForUniqueUpdate[A: Write](sql: String, arg: A): LogEvent = {
     val cio = sql"create table if not exists foo (bar integer)".update.run *>
       Update[A](sql, None).run(arg)
     eventForCIO(cio)
@@ -66,7 +64,7 @@ class LogSuite extends munit.FunSuite {
 
   test("[Query] zero-arg success") {
     val Sql = "select 1"
-    eventForUniqueQuery(Sql) match {
+    eventForUniqueQuery(Sql, ()) match {
       case Success(Sql, Nil, _, _) => ()
       case a => fail(s"no match: $a")
     }
@@ -82,7 +80,7 @@ class LogSuite extends munit.FunSuite {
 
   test("[Query] zero-arg processing failure") {
     val Sql = "select 1 where 1 = 2"
-    eventForUniqueQuery(Sql) match {
+    eventForUniqueQuery(Sql, ()) match {
       case ProcessingFailure(Sql, Nil, _, _, _) => ()
       case a => fail(s"no match: $a")
     }
@@ -110,7 +108,7 @@ class LogSuite extends munit.FunSuite {
 
   test("[Update] zero-arg success") {
     val Sql = "update foo set bar = 42"
-    eventForUniqueUpdate(Sql) match {
+    eventForUniqueUpdate(Sql, ()) match {
       case Success(Sql, Nil, _, _) => ()
       case a => fail(s"no match: $a")
     }

--- a/modules/core/src/test/scala/doobie/util/PutSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/PutSuite.scala
@@ -32,12 +32,26 @@ class PutSuite extends munit.FunSuite with PutSuitePlatform {
     Put[String]: Unit
   }
 
-  test("Put should be derived for unary products") {
+  test("Put should be auto derived for unary products") {
+    import doobie.generic.auto.*
+
     Put[X]: Unit
     Put[Q]: Unit
   }
 
+  test("Put is not auto derived without an import") {
+    val _ = compileErrors("Put[X]")
+    val _ = compileErrors("Put[Q]")
+  }
+
+  test("Put can be manually derived for unary products") {
+    Put.derived[X]: Unit
+    Put.derived[Q]: Unit
+  }
+
   test("Put should not be derived for non-unary products") {
+    import doobie.generic.auto.*
+
     val _ = compileErrors("Put[Z]")
     val _ = compileErrors("Put[(Int, Int)]")
     val _ = compileErrors("Put[S.type]")

--- a/modules/core/src/test/scala/doobie/util/QuerySuite.scala
+++ b/modules/core/src/test/scala/doobie/util/QuerySuite.scala
@@ -12,8 +12,8 @@ import doobie.util.query.Query0
 import doobie.util.transactor.Transactor
 
 class QuerySuite extends munit.FunSuite {
-
   import cats.effect.unsafe.implicits.global
+  import doobie.generic.auto.*
 
   val xa = Transactor.fromDriverManager[IO](
     "org.h2.Driver",

--- a/modules/core/src/test/scala/doobie/util/ReadSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/ReadSuite.scala
@@ -2,14 +2,15 @@
 // This software is licensed under the MIT License (MIT).
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
-package doobie
-package util
+package doobie.util
 
 import cats.effect.IO
 import cats.syntax.apply.*
 import cats.syntax.semigroupal.*
 import doobie.syntax.connectionio.*
 import doobie.syntax.string.*
+import doobie.util.meta.Meta
+import doobie.util.transactor.Transactor
 
 class ReadSuite extends munit.FunSuite with ReadSuitePlatform {
 
@@ -23,6 +24,11 @@ class ReadSuite extends munit.FunSuite with ReadSuitePlatform {
       Meta[String].timap(s => LenStr2(s.length, s))(_.s)
   }
 
+  case class Widget(n: Int, w: Widget.Inner)
+  object Widget {
+    case class Inner(n: Int, s: String)
+  }
+
   val xa = Transactor.fromDriverManager[IO](
     "org.h2.Driver",
     "jdbc:h2:mem:;DB_CLOSE_DELAY=-1",
@@ -31,63 +37,89 @@ class ReadSuite extends munit.FunSuite with ReadSuitePlatform {
   )
 
   test("Read should exist for some fancy types") {
-    util.Read[Int]: Unit
-    util.Read[(Int, Int)]: Unit
-    util.Read[(Int, Int, String)]: Unit
-    util.Read[(Int, (Int, String))]: Unit
+    import doobie.generic.auto.*
+
+    Read[Int]: Unit
+    Read[(Int, Int)]: Unit
+    Read[(Int, Int, String)]: Unit
+    Read[(Int, (Int, String))]: Unit
+  }
+
+  test("Read is not auto derived without an import") {
+    val _ = compileErrors("Read[(Int, Int)]")
+    val _ = compileErrors("Read[(Int, Int, String)]")
+    val _ = compileErrors("Read[(Int, (Int, String))]")
+  }
+
+  test("Read auto derives nested types") {
+    import doobie.generic.auto.*
+
+    assertEquals(Read[Widget].length, 3)
+  }
+
+  test("Read does not auto derive nested types without an import") {
+    val _ = compileErrors("Read.derived[Widget]")
+  }
+
+  test("Read can be manually derived") {
+    Read.derived[LenStr1]
   }
 
   test("Read should exist for Unit") {
-    util.Read[Unit]: Unit
-    assertEquals(util.Read[(Int, Unit)].length, 1)
+    import doobie.generic.auto.*
+
+    assertEquals(Read[Unit].length, 0)
+    assertEquals(Read[(Int, Unit)].length, 1)
   }
 
   test("Read should exist for option of some fancy types") {
-    util.Read[Option[Int]]: Unit
-    util.Read[Option[(Int, Int)]]: Unit
-    util.Read[Option[(Int, Int, String)]]: Unit
-    util.Read[Option[(Int, (Int, String))]]: Unit
-    util.Read[Option[(Int, Option[(Int, String)])]]: Unit
+    import doobie.generic.auto.*
+
+    Read[Option[Int]]: Unit
+    Read[Option[(Int, Int)]]: Unit
+    Read[Option[(Int, Int, String)]]: Unit
+    Read[Option[(Int, (Int, String))]]: Unit
+    Read[Option[(Int, Option[(Int, String)])]]: Unit
   }
 
   test("Read should exist for option of Unit") {
-    util.Read[Option[Unit]]: Unit
-    assertEquals(util.Read[Option[(Int, Unit)]].length, 1)
+    import doobie.generic.auto.*
+
+    assertEquals(Read[Option[Unit]].length, 0)
+    assertEquals(Read[Option[(Int, Unit)]].length, 1)
   }
 
   test("Read should select multi-column instance by default") {
-    assertEquals(util.Read[LenStr1].length, 2)
+    import doobie.generic.auto.*
+
+    assertEquals(Read[LenStr1].length, 2)
   }
 
   test("Read should select 1-column instance when available") {
-    assertEquals(util.Read[LenStr2].length, 1)
+    assertEquals(Read[LenStr2].length, 1)
   }
 
   test(".product should product the correct ordering of gets") {
-    import cats.syntax.all.*
-
-    val readInt = util.Read[Int]
-    val readString = util.Read[String]
+    val readInt = Read[Int]
+    val readString = Read[String]
 
     val p = readInt.product(readString)
 
-    assertEquals(p.gets, (readInt.gets ++ readString.gets))
+    assertEquals(p.gets, readInt.gets ++ readString.gets)
   }
 
   test("Read should select correct columns when combined with `ap`") {
-    val r = util.Read[Int]
-
+    val r = Read[Int]
     val c = (r, r, r, r, r).tupled
 
     val q = sql"SELECT 1, 2, 3, 4, 5".query(c).to[List]
-
     val o = q.transact(xa).unsafeRunSync()
 
     assertEquals(o, List((1, 2, 3, 4, 5)))
   }
 
   test("Read should select correct columns when combined with `product`") {
-    val r = util.Read[Int].product(util.Read[Int].product(util.Read[Int]))
+    val r = Read[Int].product(Read[Int].product(Read[Int]))
 
     val q = sql"SELECT 1, 2, 3".query(r).to[List]
     val o = q.transact(xa).unsafeRunSync()

--- a/modules/core/src/test/scala/doobie/util/WriteSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/WriteSuite.scala
@@ -2,8 +2,9 @@
 // This software is licensed under the MIT License (MIT).
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
-package doobie
-package util
+package doobie.util
+
+import doobie.util.meta.Meta
 
 class WriteSuite extends munit.FunSuite with WriteSuitePlatform {
 
@@ -15,37 +16,72 @@ class WriteSuite extends munit.FunSuite with WriteSuitePlatform {
       Meta[String].timap(s => LenStr2(s.length, s))(_.s)
   }
 
+  case class Widget(n: Int, w: Widget.Inner)
+  object Widget {
+    case class Inner(n: Int, s: String)
+  }
+
   test("Write should exist for some fancy types") {
-    util.Write[Int]: Unit
-    util.Write[(Int, Int)]: Unit
-    util.Write[(Int, Int, String)]: Unit
-    util.Write[(Int, (Int, String))]: Unit
+    import doobie.generic.auto.*
+
+    Write[Int]: Unit
+    Write[(Int, Int)]: Unit
+    Write[(Int, Int, String)]: Unit
+    Write[(Int, (Int, String))]: Unit
+  }
+
+  test("Write is not auto derived without an import") {
+    val _ = compileErrors("Write[(Int, Int)]")
+    val _ = compileErrors("Write[(Int, Int, String)]")
+    val _ = compileErrors("Write[(Int, (Int, String))]")
+  }
+
+  test("Write can be manually derived") {
+    Write.derived[LenStr1]
   }
 
   test("Write should exist for Unit") {
-    util.Write[Unit]: Unit
-    assertEquals(util.Write[(Int, Unit)].length, 1)
+    import doobie.generic.auto.*
+
+    Write[Unit]: Unit
+    assertEquals(Write[(Int, Unit)].length, 1)
   }
 
   test("Write should exist for option of some fancy types") {
-    util.Write[Option[Int]]: Unit
-    util.Write[Option[(Int, Int)]]: Unit
-    util.Write[Option[(Int, Int, String)]]: Unit
-    util.Write[Option[(Int, (Int, String))]]: Unit
-    util.Write[Option[(Int, Option[(Int, String)])]]: Unit
+    import doobie.generic.auto.*
+
+    Write[Option[Int]]: Unit
+    Write[Option[(Int, Int)]]: Unit
+    Write[Option[(Int, Int, String)]]: Unit
+    Write[Option[(Int, (Int, String))]]: Unit
+    Write[Option[(Int, Option[(Int, String)])]]: Unit
+  }
+
+  test("Write auto derives nested types") {
+    import doobie.generic.auto.*
+
+    assertEquals(Write[Widget].length, 3)
+  }
+
+  test("Write does not auto derive nested types without an import") {
+    val _ = compileErrors("Write.derived[Widget]")
   }
 
   test("Write should exist for option of Unit") {
-    util.Write[Option[Unit]]: Unit
-    assertEquals(util.Write[Option[(Int, Unit)]].length, 1)
+    import doobie.generic.auto.*
+
+    assertEquals(Write[Option[Unit]].length, 0)
+    assertEquals(Write[Option[(Int, Unit)]].length, 1)
   }
 
   test("Write should select multi-column instance by default") {
-    assertEquals(util.Write[LenStr1].length, 2)
+    import doobie.generic.auto.*
+
+    assertEquals(Write[LenStr1].length, 2)
   }
 
   test("Write should select 1-column instance when available") {
-    assertEquals(util.Write[LenStr2].length, 1)
+    assertEquals(Write[LenStr2].length, 1)
   }
 
 }

--- a/modules/core/src/test/scala/doobie/util/meta/MetaSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/meta/MetaSuite.scala
@@ -34,7 +34,6 @@ class MetaSuite extends munit.FunSuite {
 }
 
 class MetaDBSuite extends munit.FunSuite {
-
   import cats.effect.unsafe.implicits.global
 
   lazy val xa = Transactor.fromDriverManager[IO](

--- a/modules/example/src/main/scala-2/example/Orm.scala
+++ b/modules/example/src/main/scala-2/example/Orm.scala
@@ -10,6 +10,7 @@ import cats.effect.IO
 import cats.effect.IOApp
 import cats.syntax.all.*
 import doobie.free.connection.ConnectionIO
+import doobie.generic.auto.*
 import doobie.syntax.connectionio.*
 import doobie.syntax.string.*
 import doobie.util.Read

--- a/modules/example/src/main/scala/example/AnalysisTest.scala
+++ b/modules/example/src/main/scala/example/AnalysisTest.scala
@@ -4,6 +4,7 @@
 
 package example
 
+import doobie.generic.auto.*
 import doobie.postgres.implicits.*
 import doobie.syntax.all.*
 import doobie.util.meta.Meta

--- a/modules/example/src/main/scala/example/CustomReadWrite.scala
+++ b/modules/example/src/main/scala/example/CustomReadWrite.scala
@@ -4,6 +4,7 @@
 
 package example
 
+import doobie.generic.auto.*
 import doobie.syntax.all.*
 import doobie.util.Read
 import doobie.util.Write

--- a/modules/example/src/main/scala/example/FirstExample.scala
+++ b/modules/example/src/main/scala/example/FirstExample.scala
@@ -11,6 +11,7 @@ import cats.effect.IOApp
 import cats.syntax.all.*
 import doobie.FC
 import doobie.free.connection.ConnectionIO
+import doobie.generic.auto.*
 import doobie.syntax.all.*
 import doobie.util.query.Query0
 import doobie.util.transactor.Transactor

--- a/modules/example/src/main/scala/example/FragmentExample.scala
+++ b/modules/example/src/main/scala/example/FragmentExample.scala
@@ -8,6 +8,7 @@ import cats.effect.IO
 import cats.effect.IOApp
 import cats.syntax.all.*
 import doobie.syntax.all.*
+import doobie.util.Read
 import doobie.util.fragment.Fragment
 import doobie.util.transactor.Transactor
 
@@ -19,6 +20,9 @@ object FragmentExample extends IOApp.Simple {
 
   // Country Info
   final case class Info(name: String, code: String, population: Int)
+  object Info {
+    implicit val read: Read[Info] = Read.derived
+  }
 
   // Construct a Query0 with some optional filter conditions and a configurable LIMIT.
   def select(name: Option[String], pop: Option[Int], codes: List[String], limit: Long) = {

--- a/modules/example/src/main/scala/example/HiUsage.scala
+++ b/modules/example/src/main/scala/example/HiUsage.scala
@@ -10,6 +10,7 @@ import cats.effect.IOApp
 import cats.syntax.all.*
 import doobie.FC
 import doobie.free.connection.ConnectionIO
+import doobie.generic.auto.*
 import doobie.syntax.connectionio.*
 import doobie.syntax.string.*
 import doobie.util.transactor.Transactor

--- a/modules/example/src/main/scala/example/Join.scala
+++ b/modules/example/src/main/scala/example/Join.scala
@@ -5,6 +5,7 @@
 package example
 
 import cats.syntax.all.*
+import doobie.generic.auto.*
 import doobie.syntax.all.*
 import doobie.util.query.Query0
 

--- a/modules/example/src/main/scala/example/StreamToFile.scala
+++ b/modules/example/src/main/scala/example/StreamToFile.scala
@@ -7,6 +7,7 @@ package example
 import cats.effect.IO
 import cats.effect.IOApp
 import cats.syntax.all.*
+import doobie.generic.auto.*
 import doobie.syntax.all.*
 import doobie.util.transactor.Transactor
 import fs2.io.file.Files

--- a/modules/example/src/main/scala/example/StreamingCopy.scala
+++ b/modules/example/src/main/scala/example/StreamingCopy.scala
@@ -11,6 +11,7 @@ import doobie.FC
 import doobie.HC
 import doobie.free.connection.ConnectionIO
 import doobie.syntax.all.*
+import doobie.util.Read
 import doobie.util.transactor.Transactor
 import fs2.Stream
 
@@ -110,6 +111,9 @@ object StreamingCopy extends IOApp.Simple {
 
   // A data type to move.
   final case class City(id: Int, name: String, countrycode: String, district: String, population: Int)
+  object City {
+    implicit val read: Read[City] = Read.derived
+  }
 
   // A producer of cities, to be run on database 1
   def read: Stream[ConnectionIO, City] =

--- a/modules/munit/src/test/scala/doobie/munit/CheckerTests.scala
+++ b/modules/munit/src/test/scala/doobie/munit/CheckerTests.scala
@@ -20,10 +20,19 @@ trait CheckerChecks[M[_]] extends FunSuite with Checker[M] {
     "",
   )
 
-  test("trivial") { check(sql"select 1".query[Int]) }
-  test("fail".fail) { check(sql"select 1".query[String]) }
+  test("trivial") {
+    check(sql"select 1".query[Int])
+  }
 
-  test("trivial case-class") { check(sql"select 1".query[CheckerChecks.Foo[cats.Id]]) }
+  test("fail".fail) {
+    check(sql"select 1".query[String])
+  }
+
+  test("trivial case-class") {
+    import doobie.generic.auto.*
+
+    check(sql"select 1".query[CheckerChecks.Foo[cats.Id]])
+  }
 
   test("Read should select correct columns when combined with `product`") {
 
@@ -37,6 +46,8 @@ trait CheckerChecks[M[_]] extends FunSuite with Checker[M] {
   }
 
   test("Read should select correct columns for checking when combined with `ap`") {
+    import doobie.generic.auto.*
+
     val readInt = Read[(Int, Int)]
     val readIntToInt: Read[Tuple2[Int, Int] => String] =
       Read[(String, String)].map(i => k => s"$i,$k")

--- a/modules/postgres/src/main/scala/doobie/postgres/syntax/FragmentSyntax.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/syntax/FragmentSyntax.scala
@@ -32,7 +32,7 @@ class FragmentOps(f: Fragment) {
     if (fa.isEmpty) 0L.pure[ConnectionIO]
     else {
       val data = foldToString(fa)
-      PHC.pgGetCopyAPI(PFCM.copyIn(f.query.sql, new StringReader(data)))
+      PHC.pgGetCopyAPI(PFCM.copyIn(f.query[Unit].sql, new StringReader(data)))
     }
   }
 
@@ -54,7 +54,7 @@ class FragmentOps(f: Fragment) {
     // we need to run that in the finalizer of the `bracket`, and the result from that is ignored.
     Ref.of[ConnectionIO, Long](-1L).flatMap { numRowsRef =>
       val copyAll: ConnectionIO[Unit] =
-        Stream.bracketCase(PHC.pgGetCopyAPI(PFCM.copyIn(f.query.sql))) {
+        Stream.bracketCase(PHC.pgGetCopyAPI(PFCM.copyIn(f.query[Unit].sql))) {
           case (copyIn, Resource.ExitCase.Succeeded) =>
             PHC.embed(copyIn, PFCI.endCopy).flatMap(numRowsRef.set)
           case (copyIn, _) =>

--- a/modules/postgres/src/test/scala/doobie/postgres/ManyRowsSuite.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/ManyRowsSuite.scala
@@ -10,6 +10,7 @@ import doobie.syntax.string.*
 class ManyRowsSuite extends munit.FunSuite {
   import PostgresTestTransactor.xa
   import cats.effect.unsafe.implicits.global
+  import doobie.generic.auto.*
 
   test("select should take consistent memory") {
     val q = sql"""select a.name, b.name from city a, city b""".query[(String, String)]

--- a/modules/postgres/src/test/scala/doobie/postgres/TextSuite.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/TextSuite.scala
@@ -11,6 +11,7 @@ import doobie.postgres.implicits.*
 import doobie.syntax.connectionio.*
 import doobie.syntax.stream.*
 import doobie.syntax.string.*
+import doobie.util.Read
 import doobie.util.fragment.Fragment
 import fs2.Stream
 import org.scalacheck.Arbitrary.arbitrary
@@ -116,5 +117,8 @@ object TextSuite {
     j: Option[List[String]],
     k: Option[List[Int]],
   )
+  object Row {
+    implicit val read: Read[Row] = Read.derived
+  }
 
 }

--- a/modules/refined/src/test/scala/doobie/refined/RefinedSuite.scala
+++ b/modules/refined/src/test/scala/doobie/refined/RefinedSuite.scala
@@ -7,6 +7,7 @@ package doobie.refined
 import cats.Show
 import cats.effect.IO
 import cats.syntax.all.*
+import doobie.generic.auto.*
 import doobie.refined.implicits.*
 import doobie.syntax.connectionio.*
 import doobie.syntax.string.*

--- a/modules/specs2/src/test/scala/doobie/specs2/CheckerTests.scala
+++ b/modules/specs2/src/test/scala/doobie/specs2/CheckerTests.scala
@@ -23,6 +23,8 @@ trait CheckerChecks[M[_]] extends Specification with Checker[M] {
 
   // Abstract type parameters should be handled correctly
   {
+    import doobie.generic.auto.*
+
     final case class Foo[F[_]](x: Int)
     check(sql"select 1".query[Foo[Id]]): Unit
   }

--- a/modules/weaver/src/test/scala/doobie/weaver/CheckerTests.scala
+++ b/modules/weaver/src/test/scala/doobie/weaver/CheckerTests.scala
@@ -36,6 +36,8 @@ object CheckerTests extends IOSuite with IOChecker {
   final case class Foo[F[_]](x: Int)
 
   test("trivial case-class") { implicit transactor =>
+    import doobie.generic.auto.*
+
     check(sql"select 1".query[Foo[cats.Id]])
   }
 
@@ -50,6 +52,8 @@ object CheckerTests extends IOSuite with IOChecker {
   }
 
   test("Read should select correct columns for checking when combined with `ap`") { implicit transactor =>
+    import doobie.generic.auto.*
+
     val readInt = Read[(Int, Int)]
     val readIntToInt: Read[Tuple2[Int, Int] => String] =
       Read[(String, String)].map(i => k => s"$i,$k")


### PR DESCRIPTION
`Read` and `Write` instances are now only auto-derived if `doobie.implicits.*` or `doobie.generic.auto.*` is imported. Instances can be manually defined by using the `derived` method on the companion objects.