### PR TITLE
Fragment helper updates

### DIFF
--- a/modules/core/src/main/scala/doobie/util/fragments.scala
+++ b/modules/core/src/main/scala/doobie/util/fragments.scala
@@ -5,29 +5,63 @@
 package doobie
 package util
 
+import cats.Id
 import cats.Reducible
 import cats.syntax.alternative.*
 import cats.syntax.foldable.*
+import cats.syntax.reducible.*
 import doobie.syntax.foldable.*
 import doobie.syntax.string.*
 
+import scala.annotation.nowarn
+import scala.reflect.ClassTag
+
 /** Module of `Fragment` constructors. */
+@nowarn("msg=.*possible missing interpolator: detected an interpolated expression.*")
 object fragments {
 
+  /** Returns `ANY(fa0, fa1, ...)` */
+  def any[F[_]: Reducible, A: ClassTag](fa: F[A])(implicit P: Put[Array[A]]): Fragment =
+    anyIterable(fa.toIterable)
+
+  /** Returns `ANY(fa0, fa1, ...)` */
+  def anyIterable[A: ClassTag](fa: Iterable[A])(implicit P: Put[Array[A]]): Fragment =
+    fr"ANY(${Array.from(fa)})"
+
+  /**
+   * Returns `?, ?, ?, ...` if `a` corresponds to one element or `(?,?,...),
+   * (?,?,...), ...)` if `a` corresponds to more than one element
+   */
+  def commas[F[_]: Reducible, A](fa: F[A])(implicit W: Write[A]): Fragment = {
+    val sql = if (W.length == 1) "?" else List.fill(W.length)("?").foldSmash("(", ",", ")")
+    val f = W.toFragment(_, sql)
+    fa.reduceLeftTo(f) { case (fragment, v) => fr"$fragment, ${f(v)}" }
+  }
+
+  /**
+   * Same as [[commas]] but avoid callers having to provide explicit types for
+   * `F` and `A` when using [[Id]].
+   */
+  def commasId[A: Write](fa: Id[A]): Fragment = commas(fa)
+
   /** Returns `VALUES (fs0), (fs1), ...`. */
-  def values[F[_]: Reducible, A](fs: F[A])(implicit w: util.Write[A]): Fragment =
+  @deprecated("Replace with fr\"VALUES ${commas(fs)}\"", "0.14.0")
+  def values[F[_]: Reducible, A](fs: F[A])(implicit w: Write[A]): Fragment =
     fs.toList.map(a => fr0"(${w.toFragment(a)})").foldSmash1(fr0"VALUES ", fr",", fr"")
 
   /** Returns `f IN (fs0, fs1, ...)`. */
-  def in[F[_]: Reducible, A: util.Put](f: Fragment, fs: F[A]): Fragment =
+  @deprecated("Replace with fr\"IN (${commas(fs)})\"", "0.14.0")
+  def in[F[_]: Reducible, A: Put](f: Fragment, fs: F[A]): Fragment =
     fs.toList.map(a => fr0"$a").foldSmash1(f ++ fr0"IN (", fr",", fr")")
 
   /** Returns `f IN ((fs0-A, fs0-B), (fs1-A, fs1-B), ...)`. */
-  def in[F[_]: Reducible, A: util.Put, B: util.Put](f: Fragment, fs: F[(A, B)]): Fragment =
+  @deprecated("Replace with fr\"IN (${commas(fs)})\"", "0.14.0")
+  def in[F[_]: Reducible, A: Put, B: Put](f: Fragment, fs: F[(A, B)]): Fragment =
     fs.toList.map { case (a, b) => fr0"($a,$b)" }.foldSmash1(f ++ fr0"IN (", fr",", fr")")
 
   /** Returns `f NOT IN (fs0, fs1, ...)`. */
-  def notIn[F[_]: Reducible, A: util.Put](f: Fragment, fs: F[A]): Fragment =
+  @deprecated("Replace with fr\"NOT IN (${commas(fs)})\"", "0.14.0")
+  def notIn[F[_]: Reducible, A: Put](f: Fragment, fs: F[A]): Fragment =
     fs.toList.map(a => fr0"$a").foldSmash1(f ++ fr0"NOT IN (", fr",", fr")")
 
   /** Returns `(f1) AND (f2) AND ... (fn)`. */
@@ -75,6 +109,7 @@ object fragments {
     whereOr(fs.toList.unite*)
 
   /** Returns `SET f1, f2, ... fn` or the empty fragment if `fs` is empty. */
+  @deprecated("Replace with fr\"SET ${fs.toList.intercalate(fr\",\")}\"", "0.14.0")
   def set(fs: Fragment*): Fragment =
     if (fs.isEmpty) Fragment.empty else fr"SET" ++ fs.toList.intercalate(fr",")
 
@@ -82,6 +117,7 @@ object fragments {
    * Returns `SET f1, f2, ... fn` for defined `f`, if any, otherwise the empty
    * fragment.
    */
+  @deprecated("Replace with fr\"SET ${fs.toList.intercalate(fr\",\")}\"", "0.14.0")
   def setOpt(fs: Option[Fragment]*): Fragment =
     set(fs.toList.unite*)
 
@@ -89,7 +125,7 @@ object fragments {
   def parentheses(f: Fragment): Fragment = fr0"(" ++ f ++ fr")"
 
   /** Returns `?,?,...,?` for the values in `a`. */
-  def values[A](a: A)(implicit w: util.Write[A]): Fragment =
-    w.toFragment(a)
+  def values[A](a: A)(implicit W: Write[A]): Fragment =
+    W.toFragment(a)
 
 }

--- a/modules/example/src/main/scala/example/FragmentExample.scala
+++ b/modules/example/src/main/scala/example/FragmentExample.scala
@@ -14,7 +14,7 @@ import doobie.util.transactor.Transactor
 object FragmentExample extends IOApp.Simple {
 
   // Import some convenience constructors.
-  import doobie.util.fragments.in
+  import doobie.util.fragments.commas
   import doobie.util.fragments.whereAndOpt
 
   // Country Info
@@ -26,13 +26,14 @@ object FragmentExample extends IOApp.Simple {
     // Three Option[Fragment] filter conditions.
     val f1 = name.map(s => fr"name LIKE $s")
     val f2 = pop.map(n => fr"population > $n")
-    val f3 = codes.toNel.map(cs => in(fr"code", cs))
+    val f3 = codes.toNel.map(cs => fr"code IN (${commas(cs)}")
 
     // Our final query
-    val q: Fragment =
-      fr"SELECT name, code, population FROM country" ++
-        whereAndOpt(f1, f2, f3) ++
-        fr"LIMIT $limit"
+    val q: Fragment = fr"""
+      SELECT name, code, population FROM country
+      ${whereAndOpt(f1, f2, f3)}
+      LIMIT $limit
+    """
 
     // Construct a Query0
     q.query[Info]


### PR DESCRIPTION
Add `any` and `commas` fragment helpers and deprecate methods that are better written using `commas`.