### PR TITLE
Opt in auto derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 **foobie** is a fork of [doobie](https://github.com/tpolecat/doobie) that aims to try and keep source compatability.
 
 Currently contains the following changes:
+- `Read` and `Write` derivation is now opt-in via `import doobie.util.Read.Auto.*` and `import doobie.util.Write.Auto.*`
 - Java time instances are available without an explicit import
 - removed Scala 2.12 support along with *IO implicits in `doobie.implicit.*` import
 - PostGIS instances have been moved to the new `postgis` module and are available under `doobie.postgis.instances.{geography,geometry}`

--- a/modules/bench/src/main/scala/doobie/bench/select.scala
+++ b/modules/bench/src/main/scala/doobie/bench/select.scala
@@ -5,8 +5,10 @@
 package doobie.bench
 
 import cats.effect.IO
+import cats.syntax.apply.*
 import doobie.syntax.connectionio.*
 import doobie.syntax.string.*
+import doobie.util.Read
 import doobie.util.transactor.Transactor
 import org.openjdk.jmh.annotations.*
 
@@ -49,6 +51,12 @@ class bench {
       co.close()
     }
   }
+
+  implicit val read3Strings: Read[(String, String, String)] = (
+    Read[String],
+    Read[String],
+    Read[String],
+  ).tupled
 
   // Reading via .stream, which adds a fair amount of overhead
   def doobieBenchP(n: Int): Int =

--- a/modules/bench/src/main/scala/doobie/bench/text.scala
+++ b/modules/bench/src/main/scala/doobie/bench/text.scala
@@ -4,7 +4,9 @@
 
 package doobie.bench
 
-import cats.syntax.all.*
+import cats.syntax.apply.*
+import cats.syntax.foldable.*
+import cats.syntax.functor.*
 import doobie.FPS
 import doobie.HC
 import doobie.HPS
@@ -12,10 +14,14 @@ import doobie.free.connection.ConnectionIO
 import doobie.postgres.implicits.*
 import doobie.syntax.connectionio.*
 import doobie.syntax.string.*
+import doobie.util.Write
 import fs2.Stream
 import org.openjdk.jmh.annotations.*
 
 final case class Person(name: String, age: Int)
+object Person {
+  implicit val write: Write[Person] = Write.derived
+}
 
 class text {
   import cats.effect.unsafe.implicits.global
@@ -39,7 +45,7 @@ class text {
         people(n).foreach { p =>
           ps.setString(1, p.name)
           ps.setInt(2, p.age)
-          ps.addBatch
+          ps.addBatch()
         }
         ps.executeBatch.sum
       },

--- a/modules/core/src/main/scala-2/doobie/util/ReadPlatform.scala
+++ b/modules/core/src/main/scala-2/doobie/util/ReadPlatform.scala
@@ -11,7 +11,7 @@ import java.sql.ResultSet
 import scala.collection.immutable.ArraySeq
 import scala.language.experimental.macros
 
-trait ReadPlatform { this: Read.type =>
+trait ReadPlatform {
 
   type Typeclass[T] = Read[T]
 
@@ -28,6 +28,9 @@ trait ReadPlatform { this: Read.type =>
   }
 
   def derived[A]: Read[A] = macro Magnolia.gen[A]
+}
 
-  implicit def gen[A]: Read[A] = macro Magnolia.gen[A]
+trait ReadAutoPlatform extends ReadPlatform {
+
+  implicit def genRead[A]: Read[A] = macro Magnolia.gen[A]
 }

--- a/modules/core/src/main/scala-2/doobie/util/WritePlatform.scala
+++ b/modules/core/src/main/scala-2/doobie/util/WritePlatform.scala
@@ -12,7 +12,7 @@ import java.sql.ResultSet
 import scala.collection.immutable.ArraySeq
 import scala.language.experimental.macros
 
-trait WritePlatform { this: Write.type =>
+trait WritePlatform {
 
   type Typeclass[A] = Write[A]
 
@@ -46,6 +46,9 @@ trait WritePlatform { this: Write.type =>
   }
 
   def derived[A]: Write[A] = macro Magnolia.gen[A]
+}
 
-  implicit def gen[A]: Write[A] = macro Magnolia.gen[A]
+trait WriteAutoPlatform extends WritePlatform {
+
+  implicit def genWrite[A]: Write[A] = macro Magnolia.gen[A]
 }

--- a/modules/core/src/main/scala-3/doobie/util/ReadPlatform.scala
+++ b/modules/core/src/main/scala-3/doobie/util/ReadPlatform.scala
@@ -10,7 +10,7 @@ import scala.compiletime.erasedValue
 import scala.compiletime.summonInline
 import scala.deriving.Mirror
 
-trait ReadPlatform { this: Read.type =>
+trait ReadPlatform {
 
   inline def summonAll[T <: Tuple]: List[Read[?]] = {
     inline erasedValue[T] match {
@@ -30,6 +30,9 @@ trait ReadPlatform { this: Read.type =>
       }
     }
   }
+}
 
-  inline implicit def gen[A](using m: Mirror.ProductOf[A]): Read[A] = derived[A]
+trait ReadAutoPlatform extends ReadPlatform {
+
+  inline implicit def genRead[A](using m: Mirror.ProductOf[A]): Read[A] = derived[A]
 }

--- a/modules/core/src/main/scala-3/doobie/util/WritePlatform.scala
+++ b/modules/core/src/main/scala-3/doobie/util/WritePlatform.scala
@@ -11,7 +11,7 @@ import scala.compiletime.erasedValue
 import scala.compiletime.summonInline
 import scala.deriving.Mirror
 
-trait WritePlatform { this: Write.type =>
+trait WritePlatform {
 
   inline def summonAll[T <: Tuple]: List[Write[?]] = {
     inline erasedValue[T] match {
@@ -55,6 +55,9 @@ trait WritePlatform { this: Write.type =>
       }
     }
   }
+}
 
-  inline implicit def gen[A](using m: Mirror.ProductOf[A]): Write[A] = derived[A]
+trait WriteAutoPlatform extends WritePlatform {
+
+  inline implicit def genWrite[A](using m: Mirror.ProductOf[A]): Write[A] = derived[A]
 }

--- a/modules/core/src/main/scala/doobie/util/get.scala
+++ b/modules/core/src/main/scala/doobie/util/get.scala
@@ -174,7 +174,7 @@ object Get extends GetInstances {
   }
 
   /** An implicit Meta[A] means we also have an implicit Get[A]. */
-  implicit def metaProjection[A](implicit m: Meta[A]): Get[A] = m.get
+  implicit def fromMeta[A](implicit m: Meta[A]): Get[A] = m.get
 
 }
 

--- a/modules/core/src/main/scala/doobie/util/io.scala
+++ b/modules/core/src/main/scala/doobie/util/io.scala
@@ -4,7 +4,7 @@
 
 package doobie.util
 
-import cats.effect.implicits.monadCancelOps_
+import cats.effect.syntax.monadCancel.*
 import cats.syntax.applicative.*
 import cats.syntax.flatMap.*
 import cats.syntax.functor.*

--- a/modules/core/src/main/scala/doobie/util/put.scala
+++ b/modules/core/src/main/scala/doobie/util/put.scala
@@ -169,7 +169,7 @@ object Put extends PutInstances {
   }
 
   /** An implicit Meta[A] means we also have an implicit Put[A]. */
-  implicit def metaProjectionWrite[A](implicit m: Meta[A]): Put[A] = m.put
+  implicit def fromMeta[A](implicit m: Meta[A]): Put[A] = m.put
 
 }
 

--- a/modules/core/src/main/scala/doobie/util/read.scala
+++ b/modules/core/src/main/scala/doobie/util/read.scala
@@ -24,6 +24,7 @@ This can happen for a few reasons, but the most common case is that a data
 member somewhere within this type doesn't have a Get instance in scope. Here are
 some debugging hints:
 
+- For auto derivation ensure `doobie.util.Read.Auto.*` is being imported
 - For Option types, ensure that a Read instance is in scope for the non-Option version.
 - For types you expect to map to a single column ensure that a Get instance is in scope.
 - For case classes and tuples ensure that each element has a Read instance in scope.
@@ -69,6 +70,8 @@ trait Read[A] { self =>
 object Read extends Read1 {
 
   def apply[A](implicit ev: Read[A]): ev.type = ev
+
+  object Auto extends ReadAutoPlatform
 
   implicit val ReadApply: Apply[Read] = new Apply[Read] {
     override def map[A, B](fa: Read[A])(f: A => B) = fa.map(f)

--- a/modules/core/src/main/scala/doobie/util/write.scala
+++ b/modules/core/src/main/scala/doobie/util/write.scala
@@ -68,6 +68,8 @@ object Write extends Write1 {
 
   def apply[A](implicit A: Write[A]): Write[A] = A
 
+  object Auto extends WriteAutoPlatform
+
   implicit val WriteContravariantSemigroupal: ContravariantSemigroupal[Write] = new ContravariantSemigroupal[Write] {
     override def contramap[A, B](fa: Write[A])(f: B => A) = fa.contramap(f)
     override def product[A, B](fa: Write[A], fb: Write[B]) = fa.product(fb)

--- a/modules/core/src/test/scala-2/doobie/util/ReadSuitePlatform.scala
+++ b/modules/core/src/test/scala-2/doobie/util/ReadSuitePlatform.scala
@@ -2,13 +2,14 @@
 // This software is licensed under the MIT License (MIT).
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
-package doobie
-package util
+package doobie.util
 
 trait ReadSuitePlatform { self: munit.FunSuite =>
   import ReadSuite.X
 
   test("Read should exist for AnyVal") {
-    assertEquals(util.Read[X].length, 1)
+    import doobie.util.Read.Auto.*
+
+    assertEquals(Read[X].length, 1)
   }
 }

--- a/modules/core/src/test/scala-2/doobie/util/WriteSuitePlatform.scala
+++ b/modules/core/src/test/scala-2/doobie/util/WriteSuitePlatform.scala
@@ -2,13 +2,14 @@
 // This software is licensed under the MIT License (MIT).
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
-package doobie
-package util
+package doobie.util
 
 trait WriteSuitePlatform { self: munit.FunSuite =>
   import WriteSuite.X
 
   test("Write should exist for AnyVal") {
-    assertEquals(util.Write[X].length, 1)
+    import doobie.util.Write.Auto.*
+
+    assertEquals(Write[X].length, 1)
   }
 }

--- a/modules/core/src/test/scala-3/doobie/util/ReadSuitePlatform.scala
+++ b/modules/core/src/test/scala-3/doobie/util/ReadSuitePlatform.scala
@@ -2,12 +2,18 @@
 // This software is licensed under the MIT License (MIT).
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
-package doobie
-package util
+package doobie.util
 
 trait ReadSuitePlatform { self: munit.FunSuite =>
 
   test("derives") {
-    case class Foo(a: String, b: Int) derives util.Read
+    case class Foo(a: String, b: Int) derives Read
+  }
+
+  test("does not auto derive") {
+    val _ = compileErrors("""
+      case class Foo(a: String, b: Int)
+      case class Bar(a: String, foo: Foo) derives Read
+    """)
   }
 }

--- a/modules/core/src/test/scala-3/doobie/util/WriteSuitePlatform.scala
+++ b/modules/core/src/test/scala-3/doobie/util/WriteSuitePlatform.scala
@@ -2,12 +2,18 @@
 // This software is licensed under the MIT License (MIT).
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
-package doobie
-package util
+package doobie.util
 
 trait WriteSuitePlatform { self: munit.FunSuite =>
 
   test("derives") {
-    case class Foo(a: String, b: Int) derives util.Write
+    case class Foo(a: String, b: Int) derives Write
+  }
+
+  test("does not auto derive") {
+    val _ = compileErrors("""
+      case class Foo(a: String, b: Int)
+      case class Bar(a: String, foo: Foo) derives Write
+    """)
   }
 }

--- a/modules/core/src/test/scala/doobie/issue/780.scala
+++ b/modules/core/src/test/scala/doobie/issue/780.scala
@@ -10,6 +10,7 @@ import scala.annotation.nowarn
 
 @nowarn("msg=.*Foo is never used.*")
 class `780` extends munit.FunSuite {
+  import doobie.util.Write.Auto.*
 
   test("deriving instances should work correctly for Write from class scope") {
     class Foo[A: Write, B: Write] {

--- a/modules/core/src/test/scala/doobie/syntax/StringSuite.scala
+++ b/modules/core/src/test/scala/doobie/syntax/StringSuite.scala
@@ -7,6 +7,7 @@ package doobie.syntax
 import doobie.syntax.string.*
 
 class StringSuite extends munit.FunSuite {
+  import doobie.util.Write.Auto.*
 
   test("sql interpolator should support no-param queries") {
     val q = sql"foo bar baz".query[Int]

--- a/modules/core/src/test/scala/doobie/util/FragmentSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/FragmentSuite.scala
@@ -12,8 +12,8 @@ import doobie.util.fragment.Fragment
 import doobie.util.transactor.Transactor
 
 class FragmentSuite extends munit.FunSuite {
-
   import cats.effect.unsafe.implicits.global
+  import doobie.util.Read.Auto.*
 
   val xa = Transactor.fromDriverManager[IO](
     "org.h2.Driver",

--- a/modules/core/src/test/scala/doobie/util/FragmentsSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/FragmentsSuite.scala
@@ -17,6 +17,7 @@ import scala.annotation.nowarn
 @nowarn("cat=deprecation")
 class FragmentsSuite extends munit.FunSuite {
   import cats.effect.unsafe.implicits.global
+  import doobie.util.Write.Auto.*
   import doobie.util.fragments.*
 
   val xa = Transactor.fromDriverManager[IO](
@@ -170,7 +171,14 @@ class FragmentsSuite extends munit.FunSuite {
   }
 
   case class Person(name: String, age: Int)
+  object Person {
+    implicit val read: Read[Person] = Read.derived
+  }
+
   case class Contact(person: Person, address: Option[String])
+  object Contact {
+    implicit val read: Read[Contact] = Read.derived
+  }
 
   test("values (1)") {
     val c = Contact(Person("Bob", 42), Some("addr"))

--- a/modules/core/src/test/scala/doobie/util/GetSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/GetSuite.scala
@@ -6,9 +6,7 @@ package doobie.util
 
 import cats.effect.IO
 import doobie.Transactor
-import doobie.enumerated.JdbcType.{Array as _, *}
-import doobie.syntax.connectionio.*
-import doobie.syntax.string.*
+import doobie.enumerated.JdbcType
 
 class GetSuite extends munit.FunSuite {
 
@@ -22,8 +20,8 @@ final case class Foo(s: String)
 final case class Bar(n: Int)
 
 class GetDBSuite extends munit.FunSuite {
-
   import cats.effect.unsafe.implicits.global
+  import doobie.syntax.all.*
 
   lazy val xa = Transactor.fromDriverManager[IO](
     "org.h2.Driver",
@@ -49,7 +47,7 @@ class GetDBSuite extends munit.FunSuite {
 
   test("Get should error when reading a NULL into an unlifted Scala type (AnyRef)") {
     def x = sql"select null".query[Foo].unique.transact(xa).attempt.unsafeRunSync()
-    assertEquals(x, Left(doobie.util.invariant.NonNullableColumnRead(1, Char)))
+    assertEquals(x, Left(doobie.util.invariant.NonNullableColumnRead(1, JdbcType.Char)))
   }
 
   test("Get should not allow map to observe null on the read side (AnyVal)") {
@@ -64,7 +62,7 @@ class GetDBSuite extends munit.FunSuite {
 
   test("Get should error when reading a NULL into an unlifted Scala type (AnyVal)") {
     def x = sql"select null".query[Bar].unique.transact(xa).attempt.unsafeRunSync()
-    assertEquals(x, Left(doobie.util.invariant.NonNullableColumnRead(1, Integer)))
+    assertEquals(x, Left(doobie.util.invariant.NonNullableColumnRead(1, JdbcType.Integer)))
   }
 
   test("Get should error when reading an incorrect value") {

--- a/modules/core/src/test/scala/doobie/util/PutSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/PutSuite.scala
@@ -10,5 +10,4 @@ class PutSuite extends munit.FunSuite {
     Put[Int]: Unit
     Put[String]: Unit
   }
-
 }

--- a/modules/core/src/test/scala/doobie/util/QuerySuite.scala
+++ b/modules/core/src/test/scala/doobie/util/QuerySuite.scala
@@ -12,8 +12,8 @@ import doobie.util.query.Query0
 import doobie.util.transactor.Transactor
 
 class QuerySuite extends munit.FunSuite {
-
   import cats.effect.unsafe.implicits.global
+  import doobie.util.Read.Auto.*
 
   val xa = Transactor.fromDriverManager[IO](
     "org.h2.Driver",

--- a/modules/core/src/test/scala/doobie/util/WriteSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/WriteSuite.scala
@@ -2,8 +2,9 @@
 // This software is licensed under the MIT License (MIT).
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
-package doobie
-package util
+package doobie.util
+
+import doobie.util.meta.Meta
 
 object WriteSuite {
 
@@ -19,50 +20,89 @@ object WriteSuite {
 class WriteSuite extends munit.FunSuite with WriteSuitePlatform {
   import WriteSuite.*
 
+  case class Widget(n: Int, w: Widget.Inner)
+  object Widget {
+    case class Inner(n: Int, s: String)
+  }
+
   test("Write should exist for some fancy types") {
-    util.Write[Int]: Unit
-    util.Write[(Int, Int)]: Unit
-    util.Write[(Int, Int, String)]: Unit
-    util.Write[(Int, (Int, String))]: Unit
+    import doobie.util.Write.Auto.*
+
+    Write[Int]: Unit
+    Write[(Int, Int)]: Unit
+    Write[(Int, Int, String)]: Unit
+    Write[(Int, (Int, String))]: Unit
+  }
+
+  test("Write is not auto derived without an import") {
+    val _ = compileErrors("Write[(Int, Int)]")
+    val _ = compileErrors("Write[(Int, Int, String)]")
+    val _ = compileErrors("Write[(Int, (Int, String))]")
+  }
+
+  test("Write can be manually derived") {
+    Write.derived[LenStr1]
   }
 
   test("Write should exist for Unit") {
-    util.Write[Unit]: Unit
-    assertEquals(util.Write[(Int, Unit)].length, 1)
+    import doobie.util.Write.Auto.*
+
+    Write[Unit]: Unit
+    assertEquals(Write[(Int, Unit)].length, 1)
   }
 
   test("Write should exist for option of some fancy types") {
-    util.Write[Option[Int]]: Unit
-    util.Write[Option[(Int, Int)]]: Unit
-    util.Write[Option[(Int, Int, String)]]: Unit
-    util.Write[Option[(Int, (Int, String))]]: Unit
-    util.Write[Option[(Int, Option[(Int, String)])]]: Unit
+    import doobie.util.Write.Auto.*
+
+    Write[Option[Int]]: Unit
+    Write[Option[(Int, Int)]]: Unit
+    Write[Option[(Int, Int, String)]]: Unit
+    Write[Option[(Int, (Int, String))]]: Unit
+    Write[Option[(Int, Option[(Int, String)])]]: Unit
+  }
+
+  test("Write auto derives nested types") {
+    import doobie.util.Write.Auto.*
+
+    assertEquals(Write[Widget].length, 3)
+  }
+
+  test("Write does not auto derive nested types without an import") {
+    val _ = compileErrors("Write.derived[Widget]")
   }
 
   test("Write should exist for option of Unit") {
-    util.Write[Option[Unit]]: Unit
-    assertEquals(util.Write[Option[(Int, Unit)]].length, 1)
+    import doobie.util.Write.Auto.*
+
+    assertEquals(Write[Option[Unit]].length, 0)
+    assertEquals(Write[Option[(Int, Unit)]].length, 1)
   }
 
   test("Write should select multi-column instance by default") {
-    assertEquals(util.Write[LenStr1].length, 2)
+    import doobie.util.Write.Auto.*
+
+    assertEquals(Write[LenStr1].length, 2)
   }
 
   test("Write should select 1-column instance when available") {
-    assertEquals(util.Write[LenStr2].length, 1)
+    assertEquals(Write[LenStr2].length, 1)
   }
 
   case class Woozle(a: (String, Int), b: (Int, String), c: Boolean)
 
   test("Write should exist for some fancy types") {
-    util.Write[Woozle]: Unit
-    util.Write[(Woozle, String)]: Unit
-    util.Write[(Int, (Woozle, Woozle, String))]: Unit
+    import doobie.util.Write.Auto.*
+
+    Write[Woozle]: Unit
+    Write[(Woozle, String)]: Unit
+    Write[(Int, (Woozle, Woozle, String))]: Unit
   }
 
   test("Write should exist for option of some fancy types") {
-    util.Write[Option[Woozle]]: Unit
-    util.Write[Option[(Woozle, String)]]: Unit
-    util.Write[Option[(Int, (Woozle, Woozle, String))]]: Unit
+    import doobie.util.Write.Auto.*
+
+    Write[Option[Woozle]]: Unit
+    Write[Option[(Woozle, String)]]: Unit
+    Write[Option[(Int, (Woozle, Woozle, String))]]: Unit
   }
 }

--- a/modules/core/src/test/scala/doobie/util/meta/MetaSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/meta/MetaSuite.scala
@@ -34,7 +34,6 @@ class MetaSuite extends munit.FunSuite {
 }
 
 class MetaDBSuite extends munit.FunSuite {
-
   import cats.effect.unsafe.implicits.global
 
   lazy val xa = Transactor.fromDriverManager[IO](

--- a/modules/docs/src/main/mdoc/docs/04-Selecting.md
+++ b/modules/docs/src/main/mdoc/docs/04-Selecting.md
@@ -1,6 +1,6 @@
 ## Selecting Data
 
-In this chapter we will write some some programs to read from the database, mapping rows to Scala types on the way. We also introduce YOLO mode for experimenting with **doobie** in the REPL.
+In this chapter we will write some programs to read from the database, mapping rows to Scala types on the way. We also introduce YOLO mode for experimenting with **doobie** in the REPL.
 
 ### Setting Up
 
@@ -10,6 +10,7 @@ First let's get our imports out of the way and set up a `Transactor` as we did b
 import doobie.*
 import doobie.implicits.*
 import doobie.util.ExecutionContexts
+import doobie.util.Read.Auto.*
 import cats.*
 import cats.data.*
 import cats.effect.*

--- a/modules/docs/src/main/mdoc/docs/05-Parameterized.md
+++ b/modules/docs/src/main/mdoc/docs/05-Parameterized.md
@@ -10,6 +10,8 @@ Same as last chapter, so if you're still set up you can skip this section. Other
 import doobie.*
 import doobie.implicits.*
 import doobie.util.ExecutionContexts
+import doobie.util.Read.Auto.*
+import doobie.util.Write.Auto.*
 import cats.*
 import cats.data.*
 import cats.effect.*

--- a/modules/docs/src/main/mdoc/docs/06-Checking.md
+++ b/modules/docs/src/main/mdoc/docs/06-Checking.md
@@ -10,6 +10,7 @@ Our setup here is the same as last chapter, so if you're still running from last
 import doobie.*
 import doobie.implicits.*
 import doobie.util.ExecutionContexts
+import doobie.util.Read.Auto.*
 import cats.*
 import cats.data.*
 import cats.effect.*

--- a/modules/docs/src/main/mdoc/docs/07-Updating.md
+++ b/modules/docs/src/main/mdoc/docs/07-Updating.md
@@ -10,6 +10,8 @@ Again we set up a transactor and pull in YOLO mode, but this time we're not usin
 import doobie.*
 import doobie.implicits.*
 import doobie.util.ExecutionContexts
+import doobie.util.Read.Auto.*
+import doobie.util.Write.Auto.*
 import cats.*
 import cats.data.*
 import cats.effect.*

--- a/modules/docs/src/main/mdoc/docs/08-Fragments.md
+++ b/modules/docs/src/main/mdoc/docs/08-Fragments.md
@@ -10,6 +10,7 @@ Same as last chapter, so if you're still set up you can skip this section. Other
 import doobie.*
 import doobie.implicits.*
 import doobie.util.ExecutionContexts
+import doobie.util.Read.Auto.*
 import cats.*
 import cats.data.*
 import cats.effect.*

--- a/modules/docs/src/main/mdoc/docs/09-Error-Handling.md
+++ b/modules/docs/src/main/mdoc/docs/09-Error-Handling.md
@@ -8,6 +8,7 @@ In this chapter we examine a set of combinators that allow us to construct progr
 import doobie.*
 import doobie.implicits.*
 import doobie.util.ExecutionContexts
+import doobie.util.Read.Auto.*
 import cats.*
 import cats.data.*
 import cats.effect.*

--- a/modules/docs/src/main/mdoc/docs/11-Arrays.md
+++ b/modules/docs/src/main/mdoc/docs/11-Arrays.md
@@ -12,6 +12,7 @@ import doobie.implicits.*
 import doobie.postgres.*
 import doobie.postgres.implicits.*
 import doobie.util.ExecutionContexts
+import doobie.util.Read.Auto.*
 import cats.*
 import cats.data.*
 import cats.effect.*

--- a/modules/docs/src/main/mdoc/docs/12-Custom-Mappings.md
+++ b/modules/docs/src/main/mdoc/docs/12-Custom-Mappings.md
@@ -14,6 +14,8 @@ import cats.data.*
 import cats.implicits.*
 import doobie.*
 import doobie.implicits.*
+import doobie.util.Read.Auto.*
+import doobie.util.Write.Auto.*
 import io.circe.*
 import io.circe.jawn.*
 import io.circe.syntax.*

--- a/modules/docs/src/main/mdoc/docs/13-Unit-Testing.md
+++ b/modules/docs/src/main/mdoc/docs/13-Unit-Testing.md
@@ -9,6 +9,7 @@ As with earlier chapters we set up a `Transactor` and YOLO mode. We will also us
 ```scala mdoc:silent
 import doobie.*
 import doobie.implicits.*
+import doobie.util.Read.Auto.*
 import cats.*
 import cats.data.*
 import cats.effect.*

--- a/modules/docs/src/main/mdoc/docs/17-FAQ.md
+++ b/modules/docs/src/main/mdoc/docs/17-FAQ.md
@@ -11,6 +11,8 @@ import cats.implicits.*
 import doobie.*
 import doobie.implicits.*
 import doobie.util.ExecutionContexts
+import doobie.util.Read.Auto.*
+import doobie.util.Write.Auto.*
 import java.awt.geom.Point2D
 import java.util.UUID
 

--- a/modules/docs/src/main/mdoc/index.md
+++ b/modules/docs/src/main/mdoc/index.md
@@ -6,19 +6,12 @@
 
 # doobie
 
-<img align="right" src="https://cdn.rawgit.com/tpolecat/doobie/series/0.5.x/doobie_logo.svg" height="150px" style="padding-left: 20px"/>
-
-[![Travis CI](https://travis-ci.org/tpolecat/doobie.svg?branch=series%2F0.5.x)](https://travis-ci.org/tpolecat/doobie)
-[![Join the chat at https://gitter.im/tpolecat/doobie](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tpolecat/doobie?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Maven Central](https://img.shields.io/maven-central/v/org.tpolecat/doobie-core_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/org.tpolecat/doobie-core_2.12)
-[![Javadocs](https://javadoc.io/badge/org.tpolecat/doobie-core_2.12.svg)](https://javadoc.io/doc/org.tpolecat/doobie-core_2.12)
-
-
 **doobie** is a pure functional JDBC layer for Scala and [**Cats**](http://typelevel.org/cats/). It is not an ORM, nor is it a relational algebra; it simply provides a functional way to construct programs (and higher-level libraries) that use JDBC. For common use cases **doobie** provides a minimal but expressive high-level API:
 
 ```scala mdoc:silent
 import doobie.*
 import doobie.implicits.*
+import doobie.util.Read.Auto.*
 import cats.effect.IO
 import scala.concurrent.ExecutionContext
 

--- a/modules/example/src/main/scala/example/AnalysisTest.scala
+++ b/modules/example/src/main/scala/example/AnalysisTest.scala
@@ -6,7 +6,6 @@ package example
 
 import doobie.postgres.implicits.*
 import doobie.syntax.all.*
-import doobie.util.meta.Meta
 import doobie.util.query.Query0
 import doobie.util.update.Update
 import doobie.util.update.Update0
@@ -14,6 +13,8 @@ import org.postgresql.geometric.*
 
 // Some queries to test using the AnalysisTestSpec in src/test
 object AnalysisTest {
+  import doobie.util.Read.Auto.*
+  import doobie.util.Write.Auto.*
 
   final case class Country(name: String, indepYear: Int)
 
@@ -46,7 +47,6 @@ object AnalysisTest {
     """.query[PGpoint]
 
   val pointTest2 = {
-    Meta[PostgresPoint.Point] // why not? ... irritating that it must be instantiated. what to do?
     sql"""
       SELECT '(1, 2)'::point test
     """.query[PGcircle]

--- a/modules/example/src/main/scala/example/CustomReadWrite.scala
+++ b/modules/example/src/main/scala/example/CustomReadWrite.scala
@@ -13,6 +13,8 @@ import doobie.util.query.Query0
 import java.sql.Date
 
 object CustomReadWrite {
+  import Read.Auto.*
+  import Write.Auto.*
 
   final case class PosixTime(time: Long)
 

--- a/modules/example/src/main/scala/example/FirstExample.scala
+++ b/modules/example/src/main/scala/example/FirstExample.scala
@@ -20,6 +20,8 @@ import fs2.Stream
 
 // Example lifted from slick
 object FirstExample extends IOApp.Simple {
+  import doobie.util.Read.Auto.*
+  import doobie.util.Write.Auto.*
 
   // Our data model
   final case class Supplier(id: Int, name: String, street: String, city: String, state: String, zip: String)

--- a/modules/example/src/main/scala/example/FragmentExample.scala
+++ b/modules/example/src/main/scala/example/FragmentExample.scala
@@ -8,6 +8,7 @@ import cats.effect.IO
 import cats.effect.IOApp
 import cats.syntax.all.*
 import doobie.syntax.all.*
+import doobie.util.Read
 import doobie.util.fragment.Fragment
 import doobie.util.transactor.Transactor
 
@@ -19,6 +20,9 @@ object FragmentExample extends IOApp.Simple {
 
   // Country Info
   final case class Info(name: String, code: String, population: Int)
+  object Info {
+    implicit val read: Read[Info] = Read.derived
+  }
 
   // Construct a Query0 with some optional filter conditions and a configurable LIMIT.
   def select(name: Option[String], pop: Option[Int], codes: List[String], limit: Long) = {

--- a/modules/example/src/main/scala/example/HiUsage.scala
+++ b/modules/example/src/main/scala/example/HiUsage.scala
@@ -17,6 +17,7 @@ import fs2.Stream
 
 // JDBC program using the high-level API
 object HiUsage extends IOApp.Simple {
+  import doobie.util.Read.Auto.*
 
   // A very simple data type we will read
   final case class CountryCode(code: Option[String])

--- a/modules/example/src/main/scala/example/Join.scala
+++ b/modules/example/src/main/scala/example/Join.scala
@@ -9,6 +9,7 @@ import doobie.syntax.all.*
 import doobie.util.query.Query0
 
 object Join {
+  import doobie.util.Read.Auto.*
 
   final case class Country(code: String, name: String)
   final case class City(id: Int, name: String)

--- a/modules/example/src/main/scala/example/StreamToFile.scala
+++ b/modules/example/src/main/scala/example/StreamToFile.scala
@@ -8,6 +8,7 @@ import cats.effect.IO
 import cats.effect.IOApp
 import cats.syntax.all.*
 import doobie.syntax.all.*
+import doobie.util.Read.Auto.*
 import doobie.util.transactor.Transactor
 import fs2.io.file.Files
 import fs2.io.file.Path

--- a/modules/example/src/main/scala/example/StreamingCopy.scala
+++ b/modules/example/src/main/scala/example/StreamingCopy.scala
@@ -11,6 +11,7 @@ import doobie.FC
 import doobie.HC
 import doobie.free.connection.ConnectionIO
 import doobie.syntax.all.*
+import doobie.util.Read
 import doobie.util.transactor.Transactor
 import fs2.Stream
 
@@ -110,6 +111,9 @@ object StreamingCopy extends IOApp.Simple {
 
   // A data type to move.
   final case class City(id: Int, name: String, countrycode: String, district: String, population: Int)
+  object City {
+    implicit val read: Read[City] = Read.derived
+  }
 
   // A producer of cities, to be run on database 1
   def read: Stream[ConnectionIO, City] =

--- a/modules/munit/src/test/scala/doobie/munit/CheckerTests.scala
+++ b/modules/munit/src/test/scala/doobie/munit/CheckerTests.scala
@@ -20,10 +20,19 @@ trait CheckerChecks[M[_]] extends FunSuite with Checker[M] {
     "",
   )
 
-  test("trivial") { check(sql"select 1".query[Int]) }
-  test("fail".fail) { check(sql"select 1".query[String]) }
+  test("trivial") {
+    check(sql"select 1".query[Int])
+  }
 
-  test("trivial case-class") { check(sql"select 1".query[CheckerChecks.Foo[cats.Id]]) }
+  test("fail".fail) {
+    check(sql"select 1".query[String])
+  }
+
+  test("trivial case-class") {
+    import doobie.util.Read.Auto.*
+
+    check(sql"select 1".query[CheckerChecks.Foo[cats.Id]])
+  }
 
   test("Read should select correct columns when combined with `product`") {
 
@@ -37,6 +46,8 @@ trait CheckerChecks[M[_]] extends FunSuite with Checker[M] {
   }
 
   test("Read should select correct columns for checking when combined with `ap`") {
+    import doobie.util.Read.Auto.*
+
     val readInt = Read[(Int, Int)]
     val readIntToInt: Read[Tuple2[Int, Int] => String] =
       Read[(String, String)].map(i => k => s"$i,$k")

--- a/modules/postgres/src/main/scala/doobie/postgres/syntax/FragmentSyntax.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/syntax/FragmentSyntax.scala
@@ -32,7 +32,7 @@ class FragmentOps(f: Fragment) {
     if (fa.isEmpty) 0L.pure[ConnectionIO]
     else {
       val data = foldToString(fa)
-      PHC.pgGetCopyAPI(PFCM.copyIn(f.query.sql, new StringReader(data)))
+      PHC.pgGetCopyAPI(PFCM.copyIn(f.query[Unit].sql, new StringReader(data)))
     }
   }
 
@@ -54,7 +54,7 @@ class FragmentOps(f: Fragment) {
     // we need to run that in the finalizer of the `bracket`, and the result from that is ignored.
     Ref.of[ConnectionIO, Long](-1L).flatMap { numRowsRef =>
       val copyAll: ConnectionIO[Unit] =
-        Stream.bracketCase(PHC.pgGetCopyAPI(PFCM.copyIn(f.query.sql))) {
+        Stream.bracketCase(PHC.pgGetCopyAPI(PFCM.copyIn(f.query[Unit].sql))) {
           case (copyIn, Resource.ExitCase.Succeeded) =>
             PHC.embed(copyIn, PFCI.endCopy).flatMap(numRowsRef.set)
           case (copyIn, _) =>

--- a/modules/postgres/src/test/scala/doobie/postgres/ManyRowsSuite.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/ManyRowsSuite.scala
@@ -10,6 +10,7 @@ import doobie.syntax.string.*
 class ManyRowsSuite extends munit.FunSuite {
   import PostgresTestTransactor.xa
   import cats.effect.unsafe.implicits.global
+  import doobie.util.Read.Auto.*
 
   test("select should take consistent memory") {
     val q = sql"""select a.name, b.name from city a, city b""".query[(String, String)]

--- a/modules/postgres/src/test/scala/doobie/postgres/TextSuite.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/TextSuite.scala
@@ -11,6 +11,7 @@ import doobie.postgres.implicits.*
 import doobie.syntax.connectionio.*
 import doobie.syntax.stream.*
 import doobie.syntax.string.*
+import doobie.util.Read
 import doobie.util.fragment.Fragment
 import fs2.Stream
 import org.scalacheck.Arbitrary.arbitrary
@@ -116,5 +117,8 @@ object TextSuite {
     j: Option[List[String]],
     k: Option[List[Int]],
   )
+  object Row {
+    implicit val read: Read[Row] = Read.derived
+  }
 
 }

--- a/modules/refined/src/test/scala/doobie/refined/RefinedSuite.scala
+++ b/modules/refined/src/test/scala/doobie/refined/RefinedSuite.scala
@@ -10,7 +10,9 @@ import cats.syntax.all.*
 import doobie.refined.implicits.*
 import doobie.syntax.connectionio.*
 import doobie.syntax.string.*
+import doobie.util.Read.Auto.*
 import doobie.util.Write
+import doobie.util.Write.Auto.*
 import doobie.util.invariant.*
 import doobie.util.meta.Meta
 import doobie.util.transactor.Transactor
@@ -21,7 +23,6 @@ import eu.timepit.refined.api.Validate
 import eu.timepit.refined.numeric.Positive
 
 class RefinedSuite extends munit.FunSuite {
-
   import cats.effect.unsafe.implicits.global
 
   val xa = Transactor.fromDriverManager[IO](
@@ -45,7 +46,7 @@ class RefinedSuite extends munit.FunSuite {
   type PointInQuadrant1 = Point Refined Quadrant1
 
   implicit val PointComposite: Write[Point] =
-    Write[(Int, Int)].contramap((p: Point) => (p.x, p.y))
+    Write.derived[(Int, Int)].contramap((p: Point) => (p.x, p.y))
 
   implicit val quadrant1Validate: Validate.Plain[Point, Quadrant1] =
     Validate.fromPredicate(p => p.x >= 0 && p.y >= 0, p => show"($p is in quadrant 1)", Quadrant1())

--- a/modules/specs2/src/test/scala/doobie/specs2/CheckerTests.scala
+++ b/modules/specs2/src/test/scala/doobie/specs2/CheckerTests.scala
@@ -23,6 +23,8 @@ trait CheckerChecks[M[_]] extends Specification with Checker[M] {
 
   // Abstract type parameters should be handled correctly
   {
+    import doobie.util.Read.Auto.*
+
     final case class Foo[F[_]](x: Int)
     check(sql"select 1".query[Foo[Id]]): Unit
   }

--- a/modules/weaver/src/test/scala/doobie/weaver/CheckerTests.scala
+++ b/modules/weaver/src/test/scala/doobie/weaver/CheckerTests.scala
@@ -36,6 +36,8 @@ object CheckerTests extends IOSuite with IOChecker {
   final case class Foo[F[_]](x: Int)
 
   test("trivial case-class") { implicit transactor =>
+    import doobie.util.Read.Auto.*
+
     check(sql"select 1".query[Foo[cats.Id]])
   }
 
@@ -50,6 +52,8 @@ object CheckerTests extends IOSuite with IOChecker {
   }
 
   test("Read should select correct columns for checking when combined with `ap`") { implicit transactor =>
+    import doobie.util.Read.Auto.*
+
     val readInt = Read[(Int, Int)]
     val readIntToInt: Read[Tuple2[Int, Int] => String] =
       Read[(String, String)].map(i => k => s"$i,$k")


### PR DESCRIPTION
`Read` and `Write` instances are now only auto-derived if `doobie.util.Read.Auto.*` or `doobie.util.Write.Auto.*` is imported. Instances can be manually defined by using the `derived` method on the companion objects.