### PR TITLE
Update many optimizations

### DIFF
--- a/modules/core/src/main/scala/doobie/hi/connection.scala
+++ b/modules/core/src/main/scala/doobie/hi/connection.scala
@@ -8,6 +8,7 @@ import cats.Foldable
 import cats.data.Ior
 import cats.effect.kernel.syntax.monadCancel.*
 import cats.syntax.apply.*
+import cats.syntax.foldable.*
 import doobie.FC
 import doobie.FCS
 import doobie.FDMD
@@ -34,12 +35,11 @@ import doobie.util.analysis.ColumnMeta
 import doobie.util.analysis.ParameterMeta
 import doobie.util.stream.repeatEvalChunks
 import fs2.Stream
-import fs2.Stream.bracket
-import fs2.Stream.eval
 
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.Savepoint
+import scala.collection.Factory
 import scala.jdk.CollectionConverters.*
 
 /**
@@ -60,7 +60,7 @@ object connection {
   ): Stream[ConnectionIO, A] = {
 
     def prepared(ps: PreparedStatement): Stream[ConnectionIO, PreparedStatement] =
-      eval[ConnectionIO, PreparedStatement] {
+      Stream.eval[ConnectionIO, PreparedStatement] {
         val fs = FPS.setFetchSize(chunkSize)
         FC.embed(ps, fs *> prep).map(_ => ps)
       }
@@ -69,10 +69,10 @@ object connection {
       repeatEvalChunks(FC.embed(rs, resultset.getNextChunk[A](chunkSize)))
 
     val preparedStatement: Stream[ConnectionIO, PreparedStatement] =
-      bracket(create)(FC.embed(_, FPS.close)).flatMap(prepared)
+      Stream.bracket(create)(FC.embed(_, FPS.close)).flatMap(prepared)
 
     def results(ps: PreparedStatement): Stream[ConnectionIO, A] =
-      bracket(FC.embed(ps, exec))(FC.embed(_, FRS.close)).flatMap(unrolled)
+      Stream.bracket(FC.embed(ps, exec))(FC.embed(_, FRS.close)).flatMap(unrolled)
 
     preparedStatement.flatMap(results)
 
@@ -113,6 +113,21 @@ object connection {
       prep,
       HPS.addBatchesAndExecute(fa) *> FPS.getGeneratedKeys,
     )
+
+  def updateManyReturningGeneratedKeys[F[_]: Foldable, A: Write, K: Read](cols: List[String])(
+    sql: String,
+    fa: F[A],
+  )(implicit B: Factory[K, F[K]]) = {
+    if (fa.isEmpty) {
+      FC.delay(B.newBuilder.result())
+    } else {
+      val readRows = FPS.getGeneratedKeys.bracket { rs =>
+        FPS.embed(rs, resultset.build[F, K])
+      }(FPS.embed(_, FRS.close))
+
+      prepareStatementS(sql, cols)(HPS.addBatches(fa) *> FPS.executeBatch *> readRows)
+    }
+  }
 
   /** @group Transaction Control */
   val commit: ConnectionIO[Unit] =

--- a/modules/core/src/main/scala/doobie/hi/connection.scala
+++ b/modules/core/src/main/scala/doobie/hi/connection.scala
@@ -117,7 +117,7 @@ object connection {
   def updateManyReturningGeneratedKeys[F[_]: Foldable, A: Write, K: Read](cols: List[String])(
     sql: String,
     fa: F[A],
-  )(implicit B: Factory[K, F[K]]) = {
+  )(implicit B: Factory[K, F[K]]): ConnectionIO[F[K]] = {
     if (fa.isEmpty) {
       FC.delay(B.newBuilder.result())
     } else {

--- a/modules/core/src/main/scala/doobie/hi/preparedstatement.scala
+++ b/modules/core/src/main/scala/doobie/hi/preparedstatement.scala
@@ -31,7 +31,6 @@ import doobie.util.Write
 import doobie.util.analysis.*
 import doobie.util.stream.repeatEvalChunks
 import fs2.Stream
-import fs2.Stream.bracket
 
 import java.sql.ParameterMetaData
 import java.sql.ResultSetMetaData
@@ -51,7 +50,7 @@ object preparedstatement {
 
   /** @group Execution */
   def stream[A: Read](chunkSize: Int): Stream[PreparedStatementIO, A] =
-    bracket(FPS.executeQuery)(FPS.embed(_, FRS.close)).flatMap(unrolled[A](_, chunkSize))
+    Stream.bracket(FPS.executeQuery)(FPS.embed(_, FRS.close)).flatMap(unrolled[A](_, chunkSize))
 
   /**
    * Non-strict unit for capturing effects.
@@ -113,7 +112,7 @@ object preparedstatement {
 
   /** @group Execution */
   def executeUpdateWithGeneratedKeys[A: Read](chunkSize: Int): Stream[PreparedStatementIO, A] =
-    bracket(FPS.executeUpdate *> FPS.getGeneratedKeys)(FPS.embed(_, FRS.close)).flatMap(unrolled[A](_, chunkSize))
+    Stream.bracket(FPS.executeUpdate *> FPS.getGeneratedKeys)(FPS.embed(_, FRS.close)).flatMap(unrolled[A](_, chunkSize))
 
   /**
    * Compute the column `JdbcMeta` list for this `PreparedStatement`.

--- a/modules/core/src/main/scala/doobie/hi/preparedstatement.scala
+++ b/modules/core/src/main/scala/doobie/hi/preparedstatement.scala
@@ -7,7 +7,6 @@ package doobie.hi
 import cats.Foldable
 import cats.data.Ior
 import cats.effect.kernel.syntax.monadCancel.*
-import cats.syntax.applicative.*
 import cats.syntax.apply.*
 import cats.syntax.foldable.*
 import cats.syntax.traverse.*
@@ -63,7 +62,7 @@ object preparedstatement {
 
   /** @group Batching */
   val executeBatch: PreparedStatementIO[List[Int]] =
-    FPS.executeBatch.map(_.toIndexedSeq.toList) // intArrayOps does not have `toList` in 2.13
+    FPS.executeBatch.map(_.toList)
 
   /** @group Batching */
   val addBatch: PreparedStatementIO[Unit] =
@@ -76,17 +75,29 @@ object preparedstatement {
    * change.
    * @group Batching
    */
-  def addBatchesAndExecute[F[_]: Foldable, A: Write](fa: F[A]): PreparedStatementIO[Int] =
-    fa.toList
-      .foldRight(executeBatch)((a, b) => set(a) *> addBatch *> b)
-      .map(_.foldLeft(0)((acc, n) => acc + n.max(0))) // treat negatives (failures) as no rows updated
+  def addBatchesAndExecute[F[_]: Foldable, A: Write](fa: F[A]): PreparedStatementIO[Int] = {
+    val ps = if (fa.isEmpty) {
+      delay(Nil)
+    } else {
+      addBatches(fa) *> executeBatch
+    }
+    ps.map(_.foldLeft(0)((acc, n) => acc + n.max(0))) // treat negatives (failures) as no rows updated
+  }
 
   /**
    * Add many sets of parameters.
    * @group Batching
    */
   def addBatches[F[_]: Foldable, A: Write](fa: F[A]): PreparedStatementIO[Unit] =
-    fa.toList.foldRight(().pure[PreparedStatementIO])((a, b) => set(a) *> addBatch *> b)
+    addBatchesIterable(fa.toIterable)
+
+  private def addBatchesIterable[A](fa: Iterable[A])(implicit W: Write[A]): PreparedStatementIO[Unit] =
+    FPS.raw { ps =>
+      fa.foreach { a =>
+        W.unsafeSet(ps, 1, a)
+        ps.addBatch()
+      }
+    }
 
   /** @group Execution */
   def executeQuery[A](k: ResultSetIO[A]): PreparedStatementIO[A] =
@@ -98,7 +109,7 @@ object preparedstatement {
 
   /** @group Execution */
   def executeUpdateWithUniqueGeneratedKeys[A: Read]: PreparedStatementIO[A] =
-    executeUpdate.flatMap(_ => getUniqueGeneratedKeys[A])
+    executeUpdate *> getUniqueGeneratedKeys[A]
 
   /** @group Execution */
   def executeUpdateWithGeneratedKeys[A: Read](chunkSize: Int): Stream[PreparedStatementIO, A] =

--- a/modules/core/src/main/scala/doobie/hi/statement.scala
+++ b/modules/core/src/main/scala/doobie/hi/statement.scala
@@ -32,7 +32,7 @@ object statement {
 
   /** @group Execution */
   val executeBatch: StatementIO[List[Int]] =
-    FS.executeBatch.map(_.toIndexedSeq.toList) // intArrayOps does not have `toList` in 2.13
+    FS.executeBatch.map(_.toList)
 
   /** @group Execution */
   def executeQuery[A](sql: String)(k: ResultSetIO[A]): StatementIO[A] =

--- a/modules/core/src/main/scala/doobie/package.scala
+++ b/modules/core/src/main/scala/doobie/package.scala
@@ -46,10 +46,10 @@ package object doobie {
   val FSO = doobie.free.sqloutput
   val FS = doobie.free.statement
 
-  val HC = doobie.hi.connection
-  val HS = doobie.hi.statement
-  val HPS = doobie.hi.preparedstatement
-  val HRS = doobie.hi.resultset
+  val HC = doobie.hi.HC
+  val HS = doobie.hi.HS
+  val HPS = doobie.hi.HPS
+  val HRS = doobie.hi.HRS
 
   type Meta[A] = doobie.util.meta.Meta[A]
   val Meta = doobie.util.meta.Meta


### PR DESCRIPTION
Optimize `addBatches` to call methods on the underlying `PreparedStatement` directly instead of using `set` and `addBatch`.

A new method `updateManyReturningGeneratedKeys` has been created which works the same as `updateManyWithGeneratedKeys` but returns a collection instead of a stream. Use in cases where a known value of rows were given and the overhead of having a stream is not required.