### PR TITLE
Postgres module tweaks

### DIFF
--- a/modules/postgres-circe/src/main/scala/doobie/postgres/circe/Instances.scala
+++ b/modules/postgres-circe/src/main/scala/doobie/postgres/circe/Instances.scala
@@ -4,8 +4,6 @@
 
 package doobie.postgres.circe
 
-import cats.Show
-import cats.data.NonEmptyList
 import cats.syntax.either.*
 import cats.syntax.show.*
 import doobie.Get
@@ -13,29 +11,15 @@ import doobie.Put
 import io.circe.*
 import io.circe.jawn.*
 import io.circe.syntax.*
-import org.postgresql.util.PGobject
 
 object Instances {
 
-  private implicit val showPGobject: Show[PGobject] = Show.show(_.getValue.take(250))
-
   trait JsonbInstances {
     implicit val jsonbPut: Put[Json] =
-      Put.Advanced.other[PGobject](
-        NonEmptyList.of("jsonb"),
-      ).tcontramap { a =>
-        val o = new PGobject
-        o.setType("jsonb")
-        o.setValue(a.noSpaces)
-        o
-      }
+      doobie.postgres.instances.json.jsonbPutFromString(_.noSpaces)
 
     implicit val jsonbGet: Get[Json] =
-      Get.Advanced.other[PGobject](
-        NonEmptyList.of("jsonb"),
-      ).temap(a =>
-        parse(a.getValue).leftMap(_.show),
-      )
+      doobie.postgres.instances.json.jsonbGetFromString(parse(_).leftMap(_.show))
 
     def pgEncoderPutT[A: Encoder]: Put[A] =
       Put[Json].tcontramap(_.asJson)
@@ -53,21 +37,10 @@ object Instances {
 
   trait JsonInstances {
     implicit val jsonPut: Put[Json] =
-      Put.Advanced.other[PGobject](
-        NonEmptyList.of("json"),
-      ).tcontramap { a =>
-        val o = new PGobject
-        o.setType("json")
-        o.setValue(a.noSpaces)
-        o
-      }
+      doobie.postgres.instances.json.jsonPutFromString(_.noSpaces)
 
     implicit val jsonGet: Get[Json] =
-      Get.Advanced.other[PGobject](
-        NonEmptyList.of("json"),
-      ).temap(a =>
-        parse(a.getValue).leftMap(_.show),
-      )
+      doobie.postgres.instances.json.jsonGetFromString(parse(_).leftMap(_.show))
 
     def pgEncoderPutT[A: Encoder]: Put[A] =
       Put[Json].tcontramap(_.asJson)

--- a/modules/postgres/src/main/scala/doobie/postgres/Instances.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/Instances.scala
@@ -4,33 +4,21 @@
 
 package doobie.postgres
 
-import cats.data.NonEmptyList
-import doobie.enumerated.JdbcType
-import doobie.util.invariant.*
 import doobie.util.meta.Meta
-import org.postgresql.geometric.*
 import org.postgresql.util.*
-import org.tpolecat.typename.*
 
 import java.net.InetAddress
 import java.util.Map as JMap
 import java.util.UUID
 import scala.jdk.CollectionConverters.*
-import scala.reflect.ClassTag
 
-trait Instances {
+trait Instances
+  extends instances.ArrayInstances
+  with instances.EnumerationInstances
+  with instances.GeometricInstances {
 
   // N.B. `Meta` is the lowest-level mapping and must always cope with NULL. Easy to forget.
 
-  // Geometric Types, minus PGline which is "not fully implemented"
-  implicit val PGboxType: Meta[PGbox] = Meta.Advanced.other[PGbox]("box")
-  implicit val PGcircleType: Meta[PGcircle] = Meta.Advanced.other[PGcircle]("circle")
-  implicit val PGlsegType: Meta[PGlseg] = Meta.Advanced.other[PGlseg]("lseg")
-  implicit val PGpathType: Meta[PGpath] = Meta.Advanced.other[PGpath]("path")
-  implicit val PGpointType: Meta[PGpoint] = Meta.Advanced.other[PGpoint]("point")
-  implicit val PGpolygonType: Meta[PGpolygon] = Meta.Advanced.other[PGpolygon]("polygon")
-
-  // PGmoney doesn't seem to work:
   // PSQLException: : Bad value for type double : 1,234.56  (AbstractJdbc2ResultSet.java:3059)
   //   org.postgresql.jdbc2.AbstractJdbc2ResultSet.toDouble(AbstractJdbc2ResultSet.java:3059)
   //   org.postgresql.jdbc2.AbstractJdbc2ResultSet.getDouble(AbstractJdbc2ResultSet.java:2383)
@@ -59,209 +47,6 @@ trait Instances {
       o
     }.orNull,
   )
-
-  // java.sql.Array::getArray returns an Object that may be of primitive type or of boxed type,
-  // depending on the driver, so we can't really abstract over it. Also there's no telling what
-  // happens with multi-dimensional arrays since most databases don't support them. So anyway here
-  // we go with PostgreSQL support:
-  //
-  // PostgreSQL arrays show up as Array[AnyRef] with `null` for NULL, so that's mostly sensible;
-  // there would be no way to distinguish 0 from NULL otherwise for an int[], for example. So,
-  // these arrays can be multi-dimensional and can have NULL cells, but cannot have NULL slices;
-  // i.e., {{1,2,3}, {4,5,NULL}} is ok but {{1,2,3}, NULL} is not. So this means we only have to
-  // worry about Array[Array[...[A]]] and Array[Array[...[Option[A]]]] in our mappings.
-
-  // Construct a pair of Meta instances for arrays of lifted (nullable) and unlifted (non-
-  // nullable) reference types (as noted above, PostgreSQL doesn't ship arrays of primitives). The
-  // automatic lifting to Meta will give us lifted and unlifted arrays, for a total of four variants
-  // of each 1-d array type. In the non-nullable case we simply check for nulls and perform a cast;
-  // in the nullable case we must copy the array in both directions to lift/unlift Option.
-  @SuppressWarnings(Array("org.wartremover.warts.Null", "org.wartremover.warts.Throw"))
-  private def boxedPair[A >: Null <: AnyRef: ClassTag](
-    elemType: String,
-    arrayType: String,
-    arrayTypeT: String*,
-  ): (Meta[Array[A]], Meta[Array[Option[A]]]) = {
-    val raw = Meta.Advanced.array[A](elemType, arrayType, arrayTypeT*)
-    // Ensure `a`, which may be null, which is ok, contains no null elements.
-    def checkNull[B >: Null](a: Array[B], e: Exception): Array[B] =
-      if (a == null) null else if (a.exists(_ == null)) throw e else a
-    (
-      raw.timap(checkNull(_, NullableCellRead))(checkNull(_, NullableCellUpdate)),
-      raw.timap[Array[Option[A]]](_.map(Option(_)))(_.map(_.orNull).toArray),
-    )
-  }
-
-  // Arrays of lifted (nullable) and unlifted (non-nullable) Java wrapped primitives. PostgreSQL
-  // does not seem to support tinyint[](use a bytea instead) and smallint[] always arrives as Int[]
-  // so you can xmap if you need Short[]. The type names provided here are what is reported by JDBC
-  // when metadata is requested; there are numerous aliases but these are the ones we need. Nothing
-  // about this is portable, sorry. (╯°□°）╯︵ ┻━┻
-
-  private val boxedPairBoolean = boxedPair[java.lang.Boolean]("bit", "_bit")
-  implicit val unliftedBooleanArrayType: Meta[Array[java.lang.Boolean]] = boxedPairBoolean._1
-  implicit val liftedBooleanArrayType: Meta[Array[Option[java.lang.Boolean]]] = boxedPairBoolean._2
-
-  private val boxedPairInteger = boxedPair[java.lang.Integer]("int4", "_int4")
-  implicit val unliftedIntegerArrayType: Meta[Array[java.lang.Integer]] = boxedPairInteger._1
-  implicit val liftedIntegerArrayType: Meta[Array[Option[java.lang.Integer]]] = boxedPairInteger._2
-
-  private val boxedPairLong = boxedPair[java.lang.Long]("int8", "_int8")
-  implicit val unliftedLongArrayType: Meta[Array[java.lang.Long]] = boxedPairLong._1
-  implicit val liftedLongArrayType: Meta[Array[Option[java.lang.Long]]] = boxedPairLong._2
-
-  private val boxedPairFloat = boxedPair[java.lang.Float]("float4", "_float4")
-  implicit val unliftedFloatArrayType: Meta[Array[java.lang.Float]] = boxedPairFloat._1
-  implicit val liftedFloatArrayType: Meta[Array[Option[java.lang.Float]]] = boxedPairFloat._2
-
-  private val boxedPairDouble = boxedPair[java.lang.Double]("float8", "_float8")
-  implicit val unliftedDoubleArrayType: Meta[Array[java.lang.Double]] = boxedPairDouble._1
-  implicit val liftedDoubleArrayType: Meta[Array[Option[java.lang.Double]]] = boxedPairDouble._2
-
-  private val boxedPairString = boxedPair[java.lang.String]("varchar", "_varchar", "_char", "_text", "_bpchar")
-  implicit val unliftedStringArrayType: Meta[Array[java.lang.String]] = boxedPairString._1
-  implicit val liftedStringArrayType: Meta[Array[Option[java.lang.String]]] = boxedPairString._2
-
-  private val boxedPairUUID = boxedPair[java.util.UUID]("uuid", "_uuid")
-  implicit val unliftedUUIDArrayType: Meta[Array[java.util.UUID]] = boxedPairUUID._1
-  implicit val liftedUUIDArrayType: Meta[Array[Option[java.util.UUID]]] = boxedPairUUID._2
-
-  private val boxedPairBigDecimal = boxedPair[java.math.BigDecimal]("numeric", "_decimal", "_numeric")
-  implicit val unliftedBigDecimalArrayType: Meta[Array[java.math.BigDecimal]] = boxedPairBigDecimal._1
-  implicit val iftedBigDecimalArrayType: Meta[Array[Option[java.math.BigDecimal]]] = boxedPairBigDecimal._2
-
-  // Unboxed equivalents (actually identical in the lifted case). We require that B is the unboxed
-  // equivalent of A, otherwise this will fail in spectacular fashion, and we're using a cast in the
-  // lifted case because the representation is identical, assuming no nulls. In the long run this
-  // may need to become something slower but safer. Unclear.
-  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf", "org.wartremover.warts.Null"))
-  private def unboxedPair[A >: Null <: AnyRef: ClassTag, B <: AnyVal: ClassTag](f: A => B, g: B => A)(
-    implicit
-    boxed: Meta[Array[A]],
-    boxedLifted: Meta[Array[Option[A]]],
-  ): (Meta[Array[B]], Meta[Array[Option[B]]]) =
-    // TODO: assert, somehow, that A is the boxed version of B so we catch errors on instance
-    // construction, which is somewhat better than at [logical] execution time.
-    (
-      boxed.timap(a => if (a == null) null else a.map(f))(a => if (a == null) null else a.map(g)),
-      boxedLifted.timap(_.asInstanceOf[Array[Option[B]]])(_.asInstanceOf[Array[Option[A]]]),
-    )
-
-  // Arrays of lifted (nullable) and unlifted (non-nullable) AnyVals
-  private val unboxedPairBoolean =
-    unboxedPair[java.lang.Boolean, scala.Boolean](_.booleanValue, java.lang.Boolean.valueOf)
-  implicit val unliftedUnboxedBooleanArrayType: Meta[Array[scala.Boolean]] = unboxedPairBoolean._1
-  implicit val liftedUnboxedBooleanArrayType: Meta[Array[Option[scala.Boolean]]] = unboxedPairBoolean._2
-
-  private val unboxedPairInteger = unboxedPair[java.lang.Integer, scala.Int](_.intValue, java.lang.Integer.valueOf)
-  implicit val unliftedUnboxedIntegerArrayType: Meta[Array[scala.Int]] = unboxedPairInteger._1
-  implicit val liftedUnboxedIntegerArrayType: Meta[Array[Option[scala.Int]]] = unboxedPairInteger._2
-
-  private val unboxedPairLong = unboxedPair[java.lang.Long, scala.Long](_.longValue, java.lang.Long.valueOf)
-  implicit val unliftedUnboxedLongArrayType: Meta[Array[scala.Long]] = unboxedPairLong._1
-  implicit val liftedUnboxedLongArrayType: Meta[Array[Option[scala.Long]]] = unboxedPairLong._2
-
-  private val unboxedPairFloat = unboxedPair[java.lang.Float, scala.Float](_.floatValue, java.lang.Float.valueOf)
-  implicit val unliftedUnboxedFloatArrayType: Meta[Array[scala.Float]] = unboxedPairFloat._1
-  implicit val liftedUnboxedFloatArrayType: Meta[Array[Option[scala.Float]]] = unboxedPairFloat._2
-
-  private val unboxedPairDouble = unboxedPair[java.lang.Double, scala.Double](_.doubleValue, java.lang.Double.valueOf)
-  implicit val unliftedUnboxedDoubleArrayType: Meta[Array[scala.Double]] = unboxedPairDouble._1
-  implicit val liftedUnboxedDoubleArrayType: Meta[Array[Option[scala.Double]]] = unboxedPairDouble._2
-
-  // Arrays of scala.BigDecimal - special case as BigDecimal can be null
-  @SuppressWarnings(Array("org.wartremover.warts.Null"))
-  implicit val bigDecimalMeta: Meta[Array[BigDecimal]] = Meta[Array[java.math.BigDecimal]]
-    .timap(_.map(a => if (a == null) null else BigDecimal.apply(a)))(_.map(a => if (a == null) null else a.bigDecimal))
-
-  @SuppressWarnings(Array("org.wartremover.warts.Null"))
-  implicit val optionBigDecimalMeta: Meta[Array[Option[BigDecimal]]] = Meta[Array[Option[java.math.BigDecimal]]]
-    .timap(_.map(_.map(a => if (a == null) null else BigDecimal.apply(a))))(_.map(_.map(a =>
-      if (a == null) null else a.bigDecimal,
-    )))
-
-  // So, it turns out that arrays of structs don't work because something is missing from the
-  // implementation. So this means we will only be able to support primitive types for arrays.
-  //
-  // java.sql.SQLFeatureNotSupportedException: Method org.postgresql.jdbc4.Jdbc4Array.getArrayImpl(long,int,Map) is not yet implemented.
-  //   at org.postgresql.Driver.notImplemented(Driver.java:729)
-  //   at org.postgresql.jdbc2.AbstractJdbc2Array.buildArray(AbstractJdbc2Array.java:771)
-  //   at org.postgresql.jdbc2.AbstractJdbc2Array.getArrayImpl(AbstractJdbc2Array.java:171)
-  //   at org.postgresql.jdbc2.AbstractJdbc2Array.getArray(AbstractJdbc2Array.java:128)
-
-  // TODO: multidimensional arrays; in the worst case it's just copy/paste of everything above but
-  // we can certainly do better than that.
-
-  private def enumPartialMeta(name: String): Meta[String] =
-    Meta.Basic.many[String](
-      NonEmptyList.of(JdbcType.Other, JdbcType.VarChar), // https://github.com/tpolecat/doobie/issues/303
-      NonEmptyList.of(JdbcType.Other, JdbcType.VarChar),
-      Nil,
-      (rs, n) => rs.getString(n),
-      (ps, n, a) => {
-        val o = new PGobject
-        o.setValue(a)
-        o.setType(name)
-        ps.setObject(n, o)
-      },
-      (rs, n, a) => {
-        val o = new PGobject
-        o.setValue(a)
-        o.setType(name)
-        rs.updateObject(n, o)
-      },
-    )
-
-  /**
-   * Construct a `Meta` for values of the given type, mapped via `String` to the
-   * named PostgreSQL enum type.
-   */
-  def pgEnumString[A: TypeName](name: String, f: String => A, g: A => String): Meta[A] =
-    enumPartialMeta(name).timap[A](f)(g)
-
-  /**
-   * Construct a `Meta` for values of the given type, mapped via `String` to the
-   * named PostgreSQL enum type with tranparent partiality.
-   */
-  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
-  def pgEnumStringOpt[A: TypeName](name: String, f: String => Option[A], g: A => String): Meta[A] =
-    pgEnumString(name, { (s: String) => f(s).getOrElse(throw doobie.util.invariant.InvalidEnum[A](s)) }, g)
-
-  /**
-   * Construct a `Meta` for value members of the given `Enumeration`.
-   */
-  @SuppressWarnings(Array(
-    "org.wartremover.warts.Enumeration",
-    "org.wartremover.warts.Throw",
-    "org.wartremover.warts.ToString",
-  ))
-  def pgEnum(e: Enumeration, name: String): Meta[e.Value] =
-    pgEnumString[e.Value](
-      name,
-      a =>
-        try e.withName(a)
-        catch {
-          case _: NoSuchElementException => throw InvalidEnum[e.Value](a)
-        },
-      _.toString,
-    )
-
-  /**
-   * Construct a `Meta` for value members of the given Java `enum`.
-   */
-  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf", "org.wartremover.warts.Throw"))
-  def pgJavaEnum[E <: java.lang.Enum[E]: TypeName](name: String)(implicit E: ClassTag[E]): Meta[E] = {
-    val clazz = E.runtimeClass.asInstanceOf[Class[E]]
-    pgEnumString[E](
-      name,
-      a =>
-        try java.lang.Enum.valueOf(clazz, a)
-        catch {
-          case _: IllegalArgumentException => throw InvalidEnum[E](a)
-        },
-      _.name,
-    )
-  }
 
   /** HSTORE maps to a java.util.Map[String, String]. */
   implicit val hstoreMetaJava: Meta[JMap[String, String]] =

--- a/modules/postgres/src/main/scala/doobie/postgres/hi/largeobject.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/hi/largeobject.scala
@@ -4,7 +4,7 @@
 
 package doobie.postgres.hi
 
-import cats.syntax.all.*
+import cats.syntax.apply.*
 import doobie.postgres.PFLO
 import doobie.postgres.free.largeobject.LargeObjectIO
 import doobie.util.io.IOActions

--- a/modules/postgres/src/main/scala/doobie/postgres/hi/largeobjectmanager.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/hi/largeobjectmanager.scala
@@ -4,7 +4,9 @@
 
 package doobie.postgres.hi
 
-import cats.syntax.all.*
+import cats.syntax.apply.*
+import cats.syntax.flatMap.*
+import cats.syntax.functor.*
 import doobie.postgres.PFLO
 import doobie.postgres.PFLOM
 import doobie.postgres.free.largeobject.LargeObjectIO

--- a/modules/postgres/src/main/scala/doobie/postgres/instances/array.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/instances/array.scala
@@ -1,0 +1,152 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.postgres.instances
+
+import doobie.util.invariant.*
+import doobie.util.meta.Meta
+
+import scala.reflect.ClassTag
+
+object array extends ArrayInstances
+trait ArrayInstances {
+
+  // java.sql.Array::getArray returns an Object that may be of primitive type or of boxed type,
+  // depending on the driver, so we can't really abstract over it. Also there's no telling what
+  // happens with multi-dimensional arrays since most databases don't support them. So anyway here
+  // we go with PostgreSQL support:
+  //
+  // PostgreSQL arrays show up as Array[AnyRef] with `null` for NULL, so that's mostly sensible;
+  // there would be no way to distinguish 0 from NULL otherwise for an int[], for example. So,
+  // these arrays can be multi-dimensional and can have NULL cells, but cannot have NULL slices;
+  // i.e., {{1,2,3}, {4,5,NULL}} is ok but {{1,2,3}, NULL} is not. So this means we only have to
+  // worry about Array[Array[...[A]]] and Array[Array[...[Option[A]]]] in our mappings.
+
+  // Construct a pair of Meta instances for arrays of lifted (nullable) and unlifted (non-
+  // nullable) reference types (as noted above, PostgreSQL doesn't ship arrays of primitives). The
+  // automatic lifting to Meta will give us lifted and unlifted arrays, for a total of four variants
+  // of each 1-d array type. In the non-nullable case we simply check for nulls and perform a cast;
+  // in the nullable case we must copy the array in both directions to lift/unlift Option.
+  @SuppressWarnings(Array("org.wartremover.warts.Null", "org.wartremover.warts.Throw"))
+  private def boxedPair[A >: Null <: AnyRef: ClassTag](
+    elemType: String,
+    arrayType: String,
+    arrayTypeT: String*,
+  ): (Meta[Array[A]], Meta[Array[Option[A]]]) = {
+    val raw = Meta.Advanced.array[A](elemType, arrayType, arrayTypeT*)
+    // Ensure `a`, which may be null, which is ok, contains no null elements.
+    def checkNull[B >: Null](a: Array[B], e: Exception): Array[B] =
+      if (a == null) null else if (a.exists(_ == null)) throw e else a
+    (
+      raw.timap(checkNull(_, NullableCellRead))(checkNull(_, NullableCellUpdate)),
+      raw.timap[Array[Option[A]]](_.map(Option(_)))(_.map(_.orNull).toArray),
+    )
+  }
+
+  // Arrays of lifted (nullable) and unlifted (non-nullable) Java wrapped primitives. PostgreSQL
+  // does not seem to support tinyint[](use a bytea instead) and smallint[] always arrives as Int[]
+  // so you can xmap if you need Short[]. The type names provided here are what is reported by JDBC
+  // when metadata is requested; there are numerous aliases but these are the ones we need. Nothing
+  // about this is portable, sorry. (╯°□°）╯︵ ┻━┻
+
+  private val boxedPairBoolean = boxedPair[java.lang.Boolean]("bit", "_bit")
+  implicit val unliftedBooleanArrayType: Meta[Array[java.lang.Boolean]] = boxedPairBoolean._1
+  implicit val liftedBooleanArrayType: Meta[Array[Option[java.lang.Boolean]]] = boxedPairBoolean._2
+
+  private val boxedPairInteger = boxedPair[java.lang.Integer]("int4", "_int4")
+  implicit val unliftedIntegerArrayType: Meta[Array[java.lang.Integer]] = boxedPairInteger._1
+  implicit val liftedIntegerArrayType: Meta[Array[Option[java.lang.Integer]]] = boxedPairInteger._2
+
+  private val boxedPairLong = boxedPair[java.lang.Long]("int8", "_int8")
+  implicit val unliftedLongArrayType: Meta[Array[java.lang.Long]] = boxedPairLong._1
+  implicit val liftedLongArrayType: Meta[Array[Option[java.lang.Long]]] = boxedPairLong._2
+
+  private val boxedPairFloat = boxedPair[java.lang.Float]("float4", "_float4")
+  implicit val unliftedFloatArrayType: Meta[Array[java.lang.Float]] = boxedPairFloat._1
+  implicit val liftedFloatArrayType: Meta[Array[Option[java.lang.Float]]] = boxedPairFloat._2
+
+  private val boxedPairDouble = boxedPair[java.lang.Double]("float8", "_float8")
+  implicit val unliftedDoubleArrayType: Meta[Array[java.lang.Double]] = boxedPairDouble._1
+  implicit val liftedDoubleArrayType: Meta[Array[Option[java.lang.Double]]] = boxedPairDouble._2
+
+  private val boxedPairString = boxedPair[java.lang.String]("varchar", "_varchar", "_char", "_text", "_bpchar")
+  implicit val unliftedStringArrayType: Meta[Array[java.lang.String]] = boxedPairString._1
+  implicit val liftedStringArrayType: Meta[Array[Option[java.lang.String]]] = boxedPairString._2
+
+  private val boxedPairUUID = boxedPair[java.util.UUID]("uuid", "_uuid")
+  implicit val unliftedUUIDArrayType: Meta[Array[java.util.UUID]] = boxedPairUUID._1
+  implicit val liftedUUIDArrayType: Meta[Array[Option[java.util.UUID]]] = boxedPairUUID._2
+
+  private val boxedPairBigDecimal = boxedPair[java.math.BigDecimal]("numeric", "_decimal", "_numeric")
+  implicit val unliftedBigDecimalArrayType: Meta[Array[java.math.BigDecimal]] = boxedPairBigDecimal._1
+  implicit val iftedBigDecimalArrayType: Meta[Array[Option[java.math.BigDecimal]]] = boxedPairBigDecimal._2
+
+  // Unboxed equivalents (actually identical in the lifted case). We require that B is the unboxed
+  // equivalent of A, otherwise this will fail in spectacular fashion, and we're using a cast in the
+  // lifted case because the representation is identical, assuming no nulls. In the long run this
+  // may need to become something slower but safer. Unclear.
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf", "org.wartremover.warts.Null"))
+  private def unboxedPair[A >: Null <: AnyRef: ClassTag, B <: AnyVal: ClassTag](f: A => B, g: B => A)(
+    implicit
+    boxed: Meta[Array[A]],
+    boxedLifted: Meta[Array[Option[A]]],
+  ): (Meta[Array[B]], Meta[Array[Option[B]]]) =
+    // TODO: assert, somehow, that A is the boxed version of B so we catch errors on instance
+    // construction, which is somewhat better than at [logical] execution time.
+    (
+      boxed.timap(a => if (a == null) null else a.map(f))(a => if (a == null) null else a.map(g)),
+      boxedLifted.timap(_.asInstanceOf[Array[Option[B]]])(_.asInstanceOf[Array[Option[A]]]),
+    )
+
+  // Arrays of lifted (nullable) and unlifted (non-nullable) AnyVals
+  private val unboxedPairBoolean = unboxedPair[java.lang.Boolean, Boolean](_.booleanValue, java.lang.Boolean.valueOf)
+  implicit val unliftedUnboxedBooleanArrayType: Meta[Array[Boolean]] = unboxedPairBoolean._1
+  implicit val liftedUnboxedBooleanArrayType: Meta[Array[Option[Boolean]]] = unboxedPairBoolean._2
+
+  private val unboxedPairInteger = unboxedPair[java.lang.Integer, Int](_.intValue, java.lang.Integer.valueOf)
+  implicit val unliftedUnboxedIntegerArrayType: Meta[Array[Int]] = unboxedPairInteger._1
+  implicit val liftedUnboxedIntegerArrayType: Meta[Array[Option[Int]]] = unboxedPairInteger._2
+
+  private val unboxedPairLong = unboxedPair[java.lang.Long, Long](_.longValue, java.lang.Long.valueOf)
+  implicit val unliftedUnboxedLongArrayType: Meta[Array[Long]] = unboxedPairLong._1
+  implicit val liftedUnboxedLongArrayType: Meta[Array[Option[Long]]] = unboxedPairLong._2
+
+  private val unboxedPairFloat = unboxedPair[java.lang.Float, Float](_.floatValue, java.lang.Float.valueOf)
+  implicit val unliftedUnboxedFloatArrayType: Meta[Array[Float]] = unboxedPairFloat._1
+  implicit val liftedUnboxedFloatArrayType: Meta[Array[Option[Float]]] = unboxedPairFloat._2
+
+  private val unboxedPairDouble = unboxedPair[java.lang.Double, Double](_.doubleValue, java.lang.Double.valueOf)
+  implicit val unliftedUnboxedDoubleArrayType: Meta[Array[Double]] = unboxedPairDouble._1
+  implicit val liftedUnboxedDoubleArrayType: Meta[Array[Option[Double]]] = unboxedPairDouble._2
+
+  // Arrays of scala.BigDecimal - special case as BigDecimal can be null
+  @SuppressWarnings(Array("org.wartremover.warts.Null"))
+  implicit val bigDecimalMeta: Meta[Array[BigDecimal]] =
+    Meta[Array[java.math.BigDecimal]].timap(
+      _.map(a => if (a == null) null else BigDecimal.apply(a)),
+    )(
+      _.map(a => if (a == null) null else a.bigDecimal),
+    )
+
+  @SuppressWarnings(Array("org.wartremover.warts.Null"))
+  implicit val optionBigDecimalMeta: Meta[Array[Option[BigDecimal]]] =
+    Meta[Array[Option[java.math.BigDecimal]]].timap(
+      _.map(_.map(a => if (a == null) null else BigDecimal.apply(a))),
+    )(
+      _.map(_.map(a => if (a == null) null else a.bigDecimal)),
+    )
+
+  // So, it turns out that arrays of structs don't work because something is missing from the
+  // implementation. So this means we will only be able to support primitive types for arrays.
+  //
+  // java.sql.SQLFeatureNotSupportedException: Method org.postgresql.jdbc4.Jdbc4Array.getArrayImpl(long,int,Map) is not yet implemented.
+  //   at org.postgresql.Driver.notImplemented(Driver.java:729)
+  //   at org.postgresql.jdbc2.AbstractJdbc2Array.buildArray(AbstractJdbc2Array.java:771)
+  //   at org.postgresql.jdbc2.AbstractJdbc2Array.getArrayImpl(AbstractJdbc2Array.java:171)
+  //   at org.postgresql.jdbc2.AbstractJdbc2Array.getArray(AbstractJdbc2Array.java:128)
+
+  // TODO: multidimensional arrays; in the worst case it's just copy/paste of everything above but
+  // we can certainly do better than that.
+
+}

--- a/modules/postgres/src/main/scala/doobie/postgres/instances/enumeration.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/instances/enumeration.scala
@@ -1,0 +1,89 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.postgres.instances
+
+import cats.data.NonEmptyList
+import doobie.enumerated.JdbcType
+import doobie.util.invariant.*
+import doobie.util.meta.Meta
+import org.postgresql.util.*
+import org.tpolecat.typename.*
+
+import scala.reflect.ClassTag
+
+object enumeration extends EnumerationInstances
+trait EnumerationInstances {
+
+  private def enumPartialMeta(name: String): Meta[String] =
+    Meta.Basic.many[String](
+      NonEmptyList.of(JdbcType.Other, JdbcType.VarChar), // https://github.com/tpolecat/doobie/issues/303
+      NonEmptyList.of(JdbcType.Other, JdbcType.VarChar),
+      Nil,
+      (rs, n) => rs.getString(n),
+      (ps, n, a) => {
+        val o = new PGobject
+        o.setValue(a)
+        o.setType(name)
+        ps.setObject(n, o)
+      },
+      (rs, n, a) => {
+        val o = new PGobject
+        o.setValue(a)
+        o.setType(name)
+        rs.updateObject(n, o)
+      },
+    )
+
+  /**
+   * Construct a `Meta` for values of the given type, mapped via `String` to the
+   * named PostgreSQL enum type.
+   */
+  def pgEnumString[A: TypeName](name: String, f: String => A, g: A => String): Meta[A] =
+    enumPartialMeta(name).timap[A](f)(g)
+
+  /**
+   * Construct a `Meta` for values of the given type, mapped via `String` to the
+   * named PostgreSQL enum type with tranparent partiality.
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def pgEnumStringOpt[A: TypeName](name: String, f: String => Option[A], g: A => String): Meta[A] =
+    pgEnumString(name, { (s: String) => f(s).getOrElse(throw doobie.util.invariant.InvalidEnum[A](s)) }, g)
+
+  /**
+   * Construct a `Meta` for value members of the given `Enumeration`.
+   */
+  @SuppressWarnings(Array(
+    "org.wartremover.warts.Enumeration",
+    "org.wartremover.warts.Throw",
+    "org.wartremover.warts.ToString",
+  ))
+  def pgEnum(e: Enumeration, name: String): Meta[e.Value] =
+    pgEnumString[e.Value](
+      name,
+      a =>
+        try e.withName(a)
+        catch {
+          case _: NoSuchElementException => throw InvalidEnum[e.Value](a)
+        },
+      _.toString,
+    )
+
+  /**
+   * Construct a `Meta` for value members of the given Java `enum`.
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf", "org.wartremover.warts.Throw"))
+  def pgJavaEnum[E <: java.lang.Enum[E]: TypeName](name: String)(implicit E: ClassTag[E]): Meta[E] = {
+    val clazz = E.runtimeClass.asInstanceOf[Class[E]]
+    pgEnumString[E](
+      name,
+      a =>
+        try java.lang.Enum.valueOf(clazz, a)
+        catch {
+          case _: IllegalArgumentException => throw InvalidEnum[E](a)
+        },
+      _.name,
+    )
+  }
+}

--- a/modules/postgres/src/main/scala/doobie/postgres/instances/geometric.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/instances/geometric.scala
@@ -1,0 +1,16 @@
+package doobie.postgres.instances
+
+import doobie.util.meta.Meta
+import org.postgresql.geometric.*
+
+object geometric extends GeometricInstances
+trait GeometricInstances {
+
+  // Geometric Types, minus PGline which is "not fully implemented"
+  implicit val PGboxType: Meta[PGbox] = Meta.Advanced.other[PGbox]("box")
+  implicit val PGcircleType: Meta[PGcircle] = Meta.Advanced.other[PGcircle]("circle")
+  implicit val PGlsegType: Meta[PGlseg] = Meta.Advanced.other[PGlseg]("lseg")
+  implicit val PGpathType: Meta[PGpath] = Meta.Advanced.other[PGpath]("path")
+  implicit val PGpointType: Meta[PGpoint] = Meta.Advanced.other[PGpoint]("point")
+  implicit val PGpolygonType: Meta[PGpolygon] = Meta.Advanced.other[PGpolygon]("polygon")
+}

--- a/modules/postgres/src/main/scala/doobie/postgres/instances/json.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/instances/json.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.postgres.instances
+
+import cats.data.NonEmptyList
+import doobie.util.Get
+import doobie.util.Put
+import org.postgresql.util.PGobject
+import org.tpolecat.typename.TypeName
+
+object json {
+
+  def jsonGetFromString[A: TypeName](f: String => Either[String, A]): Get[A] =
+    Get.Advanced.other[PGobject](
+      NonEmptyList.of("json"),
+    ).temap { obj =>
+      f(obj.getValue)
+    }
+
+  def jsonPutFromString[A](f: A => String): Put[A] =
+    Put.Advanced.other[PGobject](
+      NonEmptyList.of("json"),
+    ).tcontramap { a =>
+      val o = new PGobject
+      o.setType("json")
+      o.setValue(f(a))
+      o
+    }
+
+  def jsonbGetFromString[A: TypeName](f: String => Either[String, A]): Get[A] =
+    Get.Advanced.other[PGobject](
+      NonEmptyList.of("jsonb"),
+    ).temap { obj =>
+      f(obj.getValue)
+    }
+
+  def jsonbPutFromString[A](f: A => String): Put[A] =
+    Put.Advanced.other[PGobject](
+      NonEmptyList.of("jsonb"),
+    ).tcontramap { a =>
+      val o = new PGobject
+      o.setType("jsonb")
+      o.setValue(f(a))
+      o
+    }
+}

--- a/modules/postgres/src/main/scala/doobie/postgres/instances/package.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/instances/package.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.postgres
+
+import cats.Show
+import org.postgresql.util.PGobject
+
+package object instances {
+
+  implicit val showPGobject: Show[PGobject] = Show.show(_.getValue.take(250))
+}

--- a/modules/postgres/src/main/scala/doobie/postgres/package.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/package.scala
@@ -28,7 +28,7 @@ package object postgres {
 
   object implicits
     extends Instances
-    with syntax.ToPostgresMonadErrorOps
+    with syntax.ToPostgresApplicativeErrorOps
     with syntax.ToFragmentOps
     with syntax.ToPostgresExplainOps
 }

--- a/modules/postgres/src/main/scala/doobie/postgres/syntax/applicativeerror.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/syntax/applicativeerror.scala
@@ -4,24 +4,13 @@
 
 package doobie.postgres.syntax
 
-import cats.MonadError
-import cats.syntax.all.*
-import doobie.free.connection.ConnectionIO
-import doobie.hi.HC
-import doobie.hi.HPS
-import doobie.hi.HRS
-import doobie.postgres.sqlstate.*
+import cats.ApplicativeError
 import doobie.util.catchsql.exceptSomeSqlState
-import doobie.util.query.Query
-import doobie.util.query.Query0
-import doobie.util.update.Update
-import doobie.util.update.Update0
 
 import scala.language.implicitConversions
 
-class PostgresMonadErrorOps[M[_], A](ma: M[A])(
-  implicit ev: MonadError[M, Throwable],
-) {
+class PostgresApplicativeErrorOps[M[_], A](ma: M[A])(implicit ev: ApplicativeError[M, Throwable]) {
+  import doobie.postgres.sqlstate.*
 
   def onSuccessfulCompletion(handler: => M[A]): M[A] =
     exceptSomeSqlState(ma) { case class00.SUCCESSFUL_COMPLETION => handler }
@@ -622,123 +611,14 @@ class PostgresMonadErrorOps[M[_], A](ma: M[A])(
 
 }
 
-trait ToPostgresMonadErrorOps {
-  implicit def toPostgresMonadErrorOps[M[_], A](ma: M[A])(
-    implicit ev: MonadError[M, Throwable],
-  ): PostgresMonadErrorOps[M, A] =
-    new PostgresMonadErrorOps(ma)
+trait ToPostgresApplicativeErrorOps {
+  implicit def toPostgresApplicativeErrorOps[M[_], A](
+    ma: M[A],
+  )(implicit ev: ApplicativeError[M, Throwable]): PostgresApplicativeErrorOps[M, A] =
+    new PostgresApplicativeErrorOps(ma)
 }
 
-trait ToPostgresExplainOps {
-  implicit def toPostgresExplainQuery0Ops(q: Query0[?]): PostgresExplainQuery0Ops =
-    new PostgresExplainQuery0Ops(q)
+object applicativeerror extends ToPostgresApplicativeErrorOps
 
-  implicit def toPostgresExplainQueryOps[A](q: Query[A, ?]): PostgresExplainQueryOps[A] =
-    new PostgresExplainQueryOps(q)
-
-  implicit def toPostgresExplainUpdate0Ops(u: Update0): PostgresExplainUpdate0Ops =
-    new PostgresExplainUpdate0Ops(u)
-
-  implicit def toPostgresExplainUpdateOps[A](u: Update[A]): PostgresExplainUpdateOps[A] =
-    new PostgresExplainUpdateOps(u)
-}
-
-class PostgresExplainQuery0Ops(self: Query0[?]) {
-
-  /**
-   * Construct a program in [[ConnectionIO]] which returns the server's query
-   * plan for the query (i.e., `EXPLAIN` output). The query is not actually
-   * executed.
-   */
-  def explain: ConnectionIO[List[String]] =
-    self.inspect { (sql, prepare) =>
-      HC.prepareStatement(s"EXPLAIN $sql")(prepare *> HPS.executeQuery(HRS.build[List, String]))
-    }
-
-  /**
-   * Construct a program in [[ConnectionIO]] which returns the server's query
-   * plan for the query, with a comparison to the actual execution (i.e.,
-   * `EXPLAIN ANALYZE` output). The query will be executed, but no results are
-   * returned.
-   */
-  def explainAnalyze: ConnectionIO[List[String]] =
-    self.inspect { (sql, prepare) =>
-      HC.prepareStatement(s"EXPLAIN ANALYZE $sql")(prepare *> HPS.executeQuery(HRS.build[List, String]))
-    }
-}
-
-class PostgresExplainQueryOps[A](self: Query[A, ?]) {
-
-  /**
-   * Apply the argument `a` to construct a program in [[ConnectionIO]] which
-   * returns the server's query plan for the query (i.e., `EXPLAIN` output). The
-   * query is not actually executed.
-   */
-  def explain(a: A): ConnectionIO[List[String]] = {
-    self.inspect(a) { (sql, prepare) =>
-      HC.prepareStatement(s"EXPLAIN $sql")(prepare *> HPS.executeQuery(HRS.build[List, String]))
-    }
-  }
-
-  /**
-   * Apply the argument `a` to construct a program in [[ConnectionIO]] which
-   * returns the server's query plan for the query, with a comparison to the
-   * actual execution (i.e., `EXPLAIN ANALYZE` output). The query will be
-   * executed, but no results are returned.
-   */
-  def explainAnalyze(a: A): ConnectionIO[List[String]] =
-    self.inspect(a) { (sql, prepare) =>
-      HC.prepareStatement(s"EXPLAIN ANALYZE $sql")(prepare *> HPS.executeQuery(HRS.build[List, String]))
-    }
-}
-
-class PostgresExplainUpdate0Ops(self: Update0) {
-
-  /**
-   * Construct a program in [[ConnectionIO]] which returns the server's query
-   * plan for the query (i.e., `EXPLAIN` output). The query is not actually
-   * executed.
-   */
-  def explain: ConnectionIO[List[String]] =
-    self.inspect { (sql, prepare) =>
-      HC.prepareStatement(s"EXPLAIN $sql")(prepare *> HPS.executeQuery(HRS.build[List, String]))
-    }
-
-  /**
-   * Construct a program in [[ConnectionIO]] which returns the server's query
-   * plan for the query, with a comparison to the actual execution (i.e.,
-   * `EXPLAIN ANALYZE` output). The query will be executed, but no results are
-   * returned.
-   */
-  def explainAnalyze: ConnectionIO[List[String]] =
-    self.inspect { (sql, prepare) =>
-      HC.prepareStatement(s"EXPLAIN ANALYZE $sql")(prepare *> HPS.executeQuery(HRS.build[List, String]))
-    }
-}
-
-class PostgresExplainUpdateOps[A](self: Update[A]) {
-
-  /**
-   * Apply the argument `a` to construct a program in [[ConnectionIO]] which
-   * returns the server's query plan for the query (i.e., `EXPLAIN` output). The
-   * query is not actually executed.
-   */
-  def explain(a: A): ConnectionIO[List[String]] = {
-    self.inspect(a) { (sql, prepare) =>
-      HC.prepareStatement(s"EXPLAIN $sql")(prepare *> HPS.executeQuery(HRS.build[List, String]))
-    }
-  }
-
-  /**
-   * Apply the argument `a` to construct a program in [[ConnectionIO]] which
-   * returns the server's query plan for the query, with a comparison to the
-   * actual execution (i.e., `EXPLAIN ANALYZE` output). The query will be
-   * executed, but no results are returned.
-   */
-  def explainAnalyze(a: A): ConnectionIO[List[String]] =
-    self.inspect(a) { (sql, prepare) =>
-      HC.prepareStatement(s"EXPLAIN ANALYZE $sql")(prepare *> HPS.executeQuery(HRS.build[List, String]))
-    }
-}
-
-object monaderror extends ToPostgresMonadErrorOps
+@deprecated("use `applicativeerror`", "0.14.2")
+object monaderror extends ToPostgresApplicativeErrorOps

--- a/modules/postgres/src/main/scala/doobie/postgres/syntax/explain.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/syntax/explain.scala
@@ -1,0 +1,129 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.postgres.syntax
+
+import cats.syntax.apply.*
+import doobie.free.connection.ConnectionIO
+import doobie.hi.HC
+import doobie.hi.HPS
+import doobie.hi.HRS
+import doobie.util.query.Query
+import doobie.util.query.Query0
+import doobie.util.update.Update
+import doobie.util.update.Update0
+
+import scala.language.implicitConversions
+
+trait ToPostgresExplainOps {
+  implicit def toPostgresExplainQuery0Ops(q: Query0[?]): PostgresExplainQuery0Ops =
+    new PostgresExplainQuery0Ops(q)
+
+  implicit def toPostgresExplainQueryOps[A](q: Query[A, ?]): PostgresExplainQueryOps[A] =
+    new PostgresExplainQueryOps(q)
+
+  implicit def toPostgresExplainUpdate0Ops(u: Update0): PostgresExplainUpdate0Ops =
+    new PostgresExplainUpdate0Ops(u)
+
+  implicit def toPostgresExplainUpdateOps[A](u: Update[A]): PostgresExplainUpdateOps[A] =
+    new PostgresExplainUpdateOps(u)
+}
+
+class PostgresExplainQuery0Ops(self: Query0[?]) {
+
+  /**
+   * Construct a program in [[ConnectionIO]] which returns the server's query
+   * plan for the query (i.e., `EXPLAIN` output). The query is not actually
+   * executed.
+   */
+  def explain: ConnectionIO[List[String]] =
+    self.inspect { (sql, prepare) =>
+      HC.prepareStatement(s"EXPLAIN $sql")(prepare *> HPS.executeQuery(HRS.build[List, String]))
+    }
+
+  /**
+   * Construct a program in [[ConnectionIO]] which returns the server's query
+   * plan for the query, with a comparison to the actual execution (i.e.,
+   * `EXPLAIN ANALYZE` output). The query will be executed, but no results are
+   * returned.
+   */
+  def explainAnalyze: ConnectionIO[List[String]] =
+    self.inspect { (sql, prepare) =>
+      HC.prepareStatement(s"EXPLAIN ANALYZE $sql")(prepare *> HPS.executeQuery(HRS.build[List, String]))
+    }
+}
+
+class PostgresExplainQueryOps[A](self: Query[A, ?]) {
+
+  /**
+   * Apply the argument `a` to construct a program in [[ConnectionIO]] which
+   * returns the server's query plan for the query (i.e., `EXPLAIN` output). The
+   * query is not actually executed.
+   */
+  def explain(a: A): ConnectionIO[List[String]] = {
+    self.inspect(a) { (sql, prepare) =>
+      HC.prepareStatement(s"EXPLAIN $sql")(prepare *> HPS.executeQuery(HRS.build[List, String]))
+    }
+  }
+
+  /**
+   * Apply the argument `a` to construct a program in [[ConnectionIO]] which
+   * returns the server's query plan for the query, with a comparison to the
+   * actual execution (i.e., `EXPLAIN ANALYZE` output). The query will be
+   * executed, but no results are returned.
+   */
+  def explainAnalyze(a: A): ConnectionIO[List[String]] =
+    self.inspect(a) { (sql, prepare) =>
+      HC.prepareStatement(s"EXPLAIN ANALYZE $sql")(prepare *> HPS.executeQuery(HRS.build[List, String]))
+    }
+}
+
+class PostgresExplainUpdate0Ops(self: Update0) {
+
+  /**
+   * Construct a program in [[ConnectionIO]] which returns the server's query
+   * plan for the query (i.e., `EXPLAIN` output). The query is not actually
+   * executed.
+   */
+  def explain: ConnectionIO[List[String]] =
+    self.inspect { (sql, prepare) =>
+      HC.prepareStatement(s"EXPLAIN $sql")(prepare *> HPS.executeQuery(HRS.build[List, String]))
+    }
+
+  /**
+   * Construct a program in [[ConnectionIO]] which returns the server's query
+   * plan for the query, with a comparison to the actual execution (i.e.,
+   * `EXPLAIN ANALYZE` output). The query will be executed, but no results are
+   * returned.
+   */
+  def explainAnalyze: ConnectionIO[List[String]] =
+    self.inspect { (sql, prepare) =>
+      HC.prepareStatement(s"EXPLAIN ANALYZE $sql")(prepare *> HPS.executeQuery(HRS.build[List, String]))
+    }
+}
+
+class PostgresExplainUpdateOps[A](self: Update[A]) {
+
+  /**
+   * Apply the argument `a` to construct a program in [[ConnectionIO]] which
+   * returns the server's query plan for the query (i.e., `EXPLAIN` output). The
+   * query is not actually executed.
+   */
+  def explain(a: A): ConnectionIO[List[String]] = {
+    self.inspect(a) { (sql, prepare) =>
+      HC.prepareStatement(s"EXPLAIN $sql")(prepare *> HPS.executeQuery(HRS.build[List, String]))
+    }
+  }
+
+  /**
+   * Apply the argument `a` to construct a program in [[ConnectionIO]] which
+   * returns the server's query plan for the query, with a comparison to the
+   * actual execution (i.e., `EXPLAIN ANALYZE` output). The query will be
+   * executed, but no results are returned.
+   */
+  def explainAnalyze(a: A): ConnectionIO[List[String]] =
+    self.inspect(a) { (sql, prepare) =>
+      HC.prepareStatement(s"EXPLAIN ANALYZE $sql")(prepare *> HPS.executeQuery(HRS.build[List, String]))
+    }
+}

--- a/modules/postgres/src/main/scala/doobie/postgres/syntax/fragment.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/syntax/fragment.scala
@@ -7,7 +7,8 @@ package doobie.postgres.syntax
 import cats.Foldable
 import cats.effect.kernel.Ref
 import cats.effect.kernel.Resource
-import cats.syntax.all.*
+import cats.syntax.applicative.*
+import cats.syntax.foldable.*
 import doobie.free.connection.ConnectionIO
 import doobie.postgres.*
 import doobie.util.fragment.Fragment

--- a/modules/postgres/src/test/scala/doobie/postgres/SyntaxSuite.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/SyntaxSuite.scala
@@ -8,7 +8,7 @@ import cats.syntax.applicative.*
 import cats.syntax.functor.*
 import doobie.FC
 import doobie.free.connection.ConnectionIO
-import doobie.postgres.syntax.monaderror.*
+import doobie.postgres.syntax.applicativeerror.*
 import zio.test.ZIOSpecDefault
 import zio.test.assertCompletes
 


### PR DESCRIPTION
Move array, enum and geometric instances into their own files.

Add json get and put helper methods to make it easy for consumers to create their own instances.

Move explain syntax into its own file.