### PR TITLE
Ensure every parameterized value is set

### DIFF
--- a/modules/core/src/main/scala/doobie/util/write.scala
+++ b/modules/core/src/main/scala/doobie/util/write.scala
@@ -112,11 +112,13 @@ sealed trait Write1 extends WritePlatform { this: Write.type =>
             case o => Option(o)
           }
       }
-      override def unsafeSet(ps: PreparedStatement, i: Int, a: Option[A]) = {
-        a.foreach(W.unsafeSet(ps, i, _))
+      override def unsafeSet(ps: PreparedStatement, i: Int, a: Option[A]) = a match {
+        case None => W.puts.zipWithIndex.foreach { case ((p, _), o) => p.unsafeSetNullable(ps, i + o, None) }
+        case Some(a) => W.unsafeSet(ps, i, a)
       }
-      override def unsafeUpdate(rs: ResultSet, i: Int, a: Option[A]) = {
-        a.foreach(W.unsafeUpdate(rs, i, _))
+      override def unsafeUpdate(rs: ResultSet, i: Int, a: Option[A]) = a match {
+        case None => W.puts.zipWithIndex.foreach { case ((p, _), o) => p.unsafeUpdateNullable(rs, i + o, None) }
+        case Some(a) => W.unsafeUpdate(rs, i, a)
       }
     }
   }


### PR DESCRIPTION
Some JDBC drivers require that every parameterized value has a value explicitly set so ensure that an optional `Write` instance sets its columns to `null` if given no value.